### PR TITLE
Use `State::default()` directly, instead of per-member.

### DIFF
--- a/examples/test_window.rs
+++ b/examples/test_window.rs
@@ -87,9 +87,7 @@ impl Default for AutoResizeState {
 }
 
 fn main() {
-    let mut state = State {
-        .. Default::default()
-    };
+    let mut state = State::default();
     let mut support = Support::init();
     let mut opened = true;
 


### PR DESCRIPTION
The example is sightly simplified that way, even though showing the
`..` notation for struct field initialization is probably a good thing
to do as well just for the learning experience.