### PR TITLE
add function to get framerate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,6 +223,7 @@ impl ImGui {
     }
     pub fn get_time(&self) -> f32 { unsafe { imgui_sys::igGetTime() } }
     pub fn get_frame_count(&self) -> i32 { unsafe { imgui_sys::igGetFrameCount() } }
+    pub fn get_frame_rate(&self) -> f32 { self.io().framerate }
     pub fn frame<'ui, 'a: 'ui>(&'a mut self, width: u32, height: u32, delta_time: f32) -> Ui<'ui> {
         {
             let io = self.io_mut();


### PR DESCRIPTION
As far as I undestand, there is no way to get framerate information, provided by imgui yet. This PR adds such ability. 

There is no `igGetFrameRate` function in C-api, so the direct acces to `io`'s field is used. 