### PR TITLE
Add hidpi support

### DIFF
--- a/examples/support/mod.rs
+++ b/examples/support/mod.rs
@@ -76,10 +76,9 @@ impl Support {
         target.clear_color(clear_color.0, clear_color.1,
                            clear_color.2, clear_color.3);
 
-        // Early return if the window closes before we get the sizes
-        let window = match self.display.get_window() { Some(x) => x, None => return };
-        let size_points = match window.get_inner_size_points() { Some(x) => x, None => return };
-        let size_pixels = match window.get_inner_size_pixels() { Some(x) => x, None => return };
+        let window = self.display.get_window().unwrap();
+        let size_points = window.get_inner_size_points().unwrap();
+        let size_pixels = window.get_inner_size_pixels().unwrap();
 
         let ui = self.imgui.frame(size_points, size_pixels, delta_f);
 

--- a/examples/support/mod.rs
+++ b/examples/support/mod.rs
@@ -56,10 +56,15 @@ impl Support {
         }
     }
 
-    pub fn update_mouse(&mut self, hidpi_factor: f32) {
-        self.imgui.set_mouse_pos(self.mouse_pos.0 as f32 / hidpi_factor, self.mouse_pos.1 as f32 / hidpi_factor);
+    pub fn update_hidpi_factor(&mut self) {
+        let hidpi_factor = self.display.get_window().expect("Failed to get window").hidpi_factor();
+        self.imgui.set_hidpi_factor(hidpi_factor);
+    }
+
+    pub fn update_mouse(&mut self) {
+        self.imgui.set_mouse_pos(self.mouse_pos.0 as f32, self.mouse_pos.1 as f32);
         self.imgui.set_mouse_down(&[self.mouse_pressed.0, self.mouse_pressed.1, self.mouse_pressed.2, false, false]);
-        self.imgui.set_mouse_wheel(self.mouse_wheel / hidpi_factor);
+        self.imgui.set_mouse_wheel(self.mouse_wheel);
     }
 
     pub fn render<'ui, 'a: 'ui , F: FnMut(&Ui<'ui>)>(
@@ -69,12 +74,8 @@ impl Support {
         let delta_f = delta.num_nanoseconds().unwrap() as f32 / 1_000_000_000.0;
         self.last_frame = now;
 
-        let hidpi_factor =
-            self.display.get_window()
-                .expect("Failed to get window")
-                .hidpi_factor();
-
-        self.update_mouse(hidpi_factor);
+        self.update_hidpi_factor();
+        self.update_mouse();
         self.mouse_wheel = 0.0;
 
         let mut target = self.display.draw();
@@ -82,7 +83,7 @@ impl Support {
                            clear_color.2, clear_color.3);
 
         let (width, height) = target.get_dimensions();
-        let ui = self.imgui.frame(width, height, hidpi_factor, delta_f);
+        let ui = self.imgui.frame(width, height, delta_f);
         f(&ui);
 
         self.renderer.render(&mut target, ui).unwrap();

--- a/examples/support/mod.rs
+++ b/examples/support/mod.rs
@@ -67,8 +67,7 @@ impl Support {
         self.imgui.set_mouse_wheel(self.mouse_wheel);
     }
 
-    pub fn render<'ui, 'a: 'ui , F: FnMut(&Ui<'ui>)>(
-            &'a mut self, clear_color: (f32, f32, f32, f32), mut f: F) {
+    pub fn render<F: FnMut(&Ui)>(&mut self, clear_color: (f32, f32, f32, f32), mut run_ui: F) {
         let now = SteadyTime::now();
         let delta = now - self.last_frame;
         let delta_f = delta.num_nanoseconds().unwrap() as f32 / 1_000_000_000.0;
@@ -84,7 +83,8 @@ impl Support {
 
         let (width, height) = target.get_dimensions();
         let ui = self.imgui.frame(width, height, delta_f);
-        f(&ui);
+
+        run_ui(&ui);
 
         self.renderer.render(&mut target, ui).unwrap();
 

--- a/src/glium_renderer.rs
+++ b/src/glium_renderer.rs
@@ -87,11 +87,15 @@ impl Renderer {
         try!(self.device_objects.upload_vertex_buffer(&self.ctx, draw_list.vtx_buffer));
         try!(self.device_objects.upload_index_buffer(&self.ctx, draw_list.idx_buffer));
 
-        let hidpi_factor = ui.imgui().hidpi_factor();
-        let (width, height) = surface.get_dimensions();
+        let (width, height) = ui.imgui().display_size();
+        let (scale_width, scale_height) = ui.imgui().display_framebuffer_scale();
 
-        let matrix = [[2.0 / (width as f32 / hidpi_factor), 0.0, 0.0, 0.0],
-                      [0.0, 2.0 / -(height as f32 / hidpi_factor), 0.0, 0.0],
+        if width == 0.0 || height == 0.0 {
+            return Ok(());
+        }
+
+        let matrix = [[2.0 / width as f32, 0.0, 0.0, 0.0],
+                      [0.0, 2.0 / -(height as f32), 0.0, 0.0],
                       [0.0, 0.0, -1.0, 0.0],
                       [-1.0, 1.0, 0.0, 1.0]];
         let font_texture_id = self.device_objects.texture.get_id() as uintptr_t;
@@ -117,10 +121,10 @@ impl Renderer {
                       &DrawParameters {
                           blend: Blend::alpha_blending(),
                           scissor: Some(Rect {
-                              left: (cmd.clip_rect.x * hidpi_factor) as u32,
-                              bottom: (height as f32 - (cmd.clip_rect.w * hidpi_factor)) as u32,
-                              width: ((cmd.clip_rect.z - cmd.clip_rect.x) * hidpi_factor) as u32,
-                              height: ((cmd.clip_rect.w - cmd.clip_rect.y) * hidpi_factor) as u32,
+                              left: (cmd.clip_rect.x * scale_width) as u32,
+                              bottom: ((height - cmd.clip_rect.w) * scale_height) as u32,
+                              width: ((cmd.clip_rect.z - cmd.clip_rect.x) * scale_width) as u32,
+                              height: ((cmd.clip_rect.w - cmd.clip_rect.y) * scale_height) as u32,
                           }),
                           ..DrawParameters::default()
                       }));

--- a/src/glium_renderer.rs
+++ b/src/glium_renderer.rs
@@ -71,17 +71,15 @@ impl Renderer {
 
     pub fn render<'a, S: Surface>(&mut self, surface: &mut S, ui: Ui<'a>) -> RendererResult<()> {
         let _ = self.ctx.insert_debug_marker("imgui-rs: starting rendering");
-        let result = ui.render(|draw_list, hidpi_factor| {
-            self.render_draw_list(surface, draw_list, hidpi_factor)
-        });
+        let result = ui.render(|ui, draw_list| self.render_draw_list(surface, ui, draw_list));
         let _ = self.ctx.insert_debug_marker("imgui-rs: rendering finished");
         result
     }
 
     fn render_draw_list<'a, S: Surface>(&mut self,
                                         surface: &mut S,
-                                        draw_list: DrawList<'a>,
-                                        hidpi_factor: f32)
+                                        ui: &'a Ui<'a>,
+                                        draw_list: DrawList<'a>)
                                         -> RendererResult<()> {
         use glium::{Blend, DrawParameters, Rect};
         use glium::uniforms::MagnifySamplerFilter;
@@ -89,6 +87,7 @@ impl Renderer {
         try!(self.device_objects.upload_vertex_buffer(&self.ctx, draw_list.vtx_buffer));
         try!(self.device_objects.upload_index_buffer(&self.ctx, draw_list.idx_buffer));
 
+        let hidpi_factor = ui.imgui().hidpi_factor();
         let (width, height) = surface.get_dimensions();
 
         let matrix = [[2.0 / (width as f32 / hidpi_factor), 0.0, 0.0, 0.0],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,7 +343,7 @@ impl<'ui> Ui<'ui> {
         io.metrics_active_windows
     }
     pub fn render<F, E>(self, mut f: F) -> Result<(), E>
-        where F: FnMut(DrawList<'ui>, f32) -> Result<(), E>
+        where F: FnMut(&Ui, DrawList) -> Result<(), E>
     {
         unsafe {
             imgui_sys::igRender();
@@ -355,7 +355,7 @@ impl<'ui> Ui<'ui> {
                     idx_buffer: (*cmd_list).idx_buffer.as_slice(),
                     vtx_buffer: (*cmd_list).vtx_buffer.as_slice(),
                 };
-                try!(f(draw_list, self.imgui.hidpi_factor));
+                try!(f(&self, draw_list));
             }
             CURRENT_UI = None;
         }


### PR DESCRIPTION
Closes #18.

<img width="1136" alt="screen shot 2016-06-13 at 2 51 11 pm" src="https://cloud.githubusercontent.com/assets/695077/15997353/4fe18f14-3176-11e6-879f-48cdabdb7091.png">

Not sure about the API design for this one. I initially had the user handle the hidpi factor themselves (see 
https://github.com/bjz/imgui-rs/commit/734eda2d5752e2f5c152ae9c61708aa961dab7c2), but I decided to move it into the `ImGui` struct and move it behind a setter. This has the least impact downstream, but requires users to remember to set the hidpi factor before setting mouse values, and means we have to do conversions when accessing/setting the mouse position and mouse wheel values.

Thoughts?

cc. ocornut/imgui#287, ocornut/imgui#426
