### PR TITLE
Add compiling notice for Windows users in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -54,6 +54,10 @@ ui.window(im_str!("Hello world"))
     cargo run --example test_window
     cargo run --example test_window_impl
 
+Note to Windows users:  You will need to use the *MSVC ABI* version of the Rust compiler along 
+with its associated [dependencies](https://www.rust-lang.org/en-US/downloads.html#win-foot) to 
+build this libary and run the examples.
+
 ## How to contribute
 
 1. Change or add something


### PR DESCRIPTION
The library will compile with the GNU version of the Rust if the underlying required Windows dependencies can be found during compilation but runtime errors will occur when running the samples due to the incompatible ABI.  I built the library and ran the examples successfully on two different machine running different versions of Windows using the Rust MSVC compiler with the latest Visual Studio 2015 C++ tools installed.