### PR TITLE
Use character input instead of string input.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,14 +260,8 @@ impl ImGui {
         io.key_map[key as usize] = mapping as i32;
     }
     pub fn add_input_character(&mut self, character: char) {
-        // TODO: This is slightly better. We should use char::encode_utf8 when it stabilizes
-        // to allow us to skip the string intermediate since we can then go directly
-        // to bytes
-        let mut string = String::new();
-        string.push(character);
-        string.push('\0');
         unsafe {
-            imgui_sys::ImGuiIO_AddInputCharactersUTF8(string.as_ptr() as *const i8);
+            imgui_sys::ImGuiIO_AddInputCharacter(character as u16);
         }
     }
     pub fn get_time(&self) -> f32 { unsafe { imgui_sys::igGetTime() } }


### PR DESCRIPTION
Fixes input on Linux at least.