### PR TITLE
Fix typos in function names

### DIFF
--- a/imgui-sys/src/lib.rs
+++ b/imgui-sys/src/lib.rs
@@ -786,7 +786,7 @@ extern "C" {
     pub fn igPushStyleColor(idx: ImGuiCol, col: ImVec4);
     pub fn igPopStyleColor(count: c_int);
     pub fn igPushStyleVar(idx: ImGuiStyleVar, val: c_float);
-    pub fn igPushStyleVavrVec(idx: ImGuiStyleVar, val: ImVec2);
+    pub fn igPushStyleVarVec(idx: ImGuiStyleVar, val: ImVec2);
     pub fn igPopStyleVar(count: c_int);
     pub fn igGetFont() -> *mut ImFont;
     pub fn igGetFontSize() -> c_float;

--- a/src/window.rs
+++ b/src/window.rs
@@ -137,7 +137,7 @@ impl<'ui, 'p> Window<'ui, 'p> {
         self
     }
     #[inline]
-    pub fn always_vertical_scollbar(mut self, value: bool) -> Self {
+    pub fn always_vertical_scrollbar(mut self, value: bool) -> Self {
         self.flags.set(ImGuiWindowFlags_AlwaysVerticalScrollbar, value);
         self
     }


### PR DESCRIPTION
Trivial fix. "igPushStyleVavrVec" wouldn't link against to the underlying C library.