### PR TITLE
Added ImInput to make it easier to handle cstr input.

### DIFF
--- a/examples/test_window_impl.rs
+++ b/examples/test_window_impl.rs
@@ -4,7 +4,6 @@ extern crate glium;
 extern crate imgui;
 
 use imgui::*;
-use std::iter::repeat;
 
 use self::support::Support;
 
@@ -31,10 +30,10 @@ struct State {
     no_menu: bool,
     bg_alpha: f32,
     wrap_width: f32,
-    buf: String,
+    buf: ImInput,
     item: i32,
     item2: i32,
-    text: String,
+    text: ImInput,
     i0: i32,
     f0: f32,
     vec2f: [f32;2],
@@ -50,13 +49,10 @@ struct State {
 
 impl Default for State {
     fn default() -> Self {
-        let mut buf = "日本語".to_owned();
-        buf.extend(repeat('\0').take(32));
-        buf.truncate(32);
-        let mut text = String::with_capacity(128);
+        let mut buf = ImInput::with_capacity(32);
+        buf.push_str("日本語");
+        let mut text = ImInput::with_capacity(128);
         text.push_str("Hello, world!");
-        let remaining = text.capacity() - text.len();
-        text.extend(repeat('\0').take(remaining));
         State {
             clear_color: (114.0 / 255.0, 144.0 / 255.0, 154.0 / 255.0, 1.0),
             show_app_metrics: false,
@@ -319,6 +315,8 @@ fn show_test_window<'a>(ui: &Ui<'a>, state: &mut State, opened: &mut bool) {
                     im_str!("IIII"), im_str!("JJJJ"), im_str!("KKKK")];
                 ui.combo(im_str!("combo scroll"), &mut state.item2, &items, -1);
                 ui.input_text(im_str!("input text"), &mut state.text).build();
+                let inputted = format!("input text \"{}\"", state.text.to_str().unwrap());
+                ui.text(ImStr::from(inputted));
                 ui.input_int(im_str!("input int"), &mut state.i0).build();
                 ui.input_float(im_str!("input float"), &mut state.f0)
                     .step(0.01).step_fast(1.0).build();

--- a/src/input.rs
+++ b/src/input.rs
@@ -10,8 +10,8 @@ use super::{ImGuiInputTextFlags,
             ImGuiInputTextFlags_CallbackCompletion, ImGuiInputTextFlags_CallbackHistory,
             ImGuiInputTextFlags_CharsDecimal, ImGuiInputTextFlags_CharsHexadecimal,
             ImGuiInputTextFlags_CharsNoBlank, ImGuiInputTextFlags_CharsUppercase,
-            ImGuiInputTextFlags_EnterReturnsTrue, ImGuiInputTextFlags_NoHorizontalScroll, ImStr,
-            Ui};
+            ImGuiInputTextFlags_EnterReturnsTrue, ImGuiInputTextFlags_NoHorizontalScroll,
+            ImInput, ImStr, Ui};
 
 macro_rules! impl_text_flags {
     ($InputType:ident) => {
@@ -130,13 +130,13 @@ macro_rules! impl_precision_params {
 #[must_use]
 pub struct InputText<'ui, 'p> {
     label: ImStr<'p>,
-    buf: &'p mut str,
+    buf: &'p mut ImInput,
     flags: ImGuiInputTextFlags,
     _phantom: PhantomData<&'ui Ui<'ui>>,
 }
 
 impl<'ui, 'p> InputText<'ui, 'p> {
-    pub fn new(label: ImStr<'p>, buf: &'p mut str) -> Self {
+    pub fn new(label: ImStr<'p>, buf: &'p mut ImInput) -> Self {
         InputText {
             label: label,
             buf: buf,
@@ -156,7 +156,7 @@ impl<'ui, 'p> InputText<'ui, 'p> {
                                    // TODO: this is evil.
                                    // Perhaps something else than &mut str is better
                                    self.buf.as_ptr() as *mut i8,
-                                   self.buf.len() as size_t,
+                                   self.buf.capacity() as size_t,
                                    self.flags,
                                    None,
                                    ptr::null_mut())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use std::ffi::CStr;
 use std::mem;
 use std::ptr;
 use std::slice;
-use std::str;
+use std::str::{self, Utf8Error};
 
 pub use imgui_sys::{ImDrawIdx, ImDrawVert, ImGuiInputTextFlags, ImGuiInputTextFlags_AllowTabInput,
                     ImGuiInputTextFlags_AlwaysInsertMode, ImGuiInputTextFlags_AutoSelectAll,
@@ -105,6 +105,40 @@ impl From<String> for ImStr<'static> {
     fn from(mut value: String) -> ImStr<'static> {
         value.push('\0');
         ImStr { bytes: Cow::Owned(value.into_bytes()) }
+    }
+}
+
+pub struct ImInput {
+    bytes: Vec<u8>,
+}
+
+impl ImInput {
+    pub fn with_capacity(capacity: usize) -> ImInput {
+        let mut bytes = Vec::with_capacity(capacity);
+        bytes.push(0);
+        ImInput {
+            bytes: bytes,
+        }
+    }
+    pub fn push_str(&mut self, s: &str) {
+        let len = self.len();
+        self.bytes.truncate(len);
+        self.bytes.extend(s.as_bytes());
+        self.bytes.push(0);
+    }
+    pub fn to_str(&self) -> Result<&str, Utf8Error> {
+        unsafe { CStr::from_ptr(self.bytes.as_ptr() as *const i8).to_str() }
+    }
+    pub fn as_ptr(&self) -> *const c_char { self.bytes.as_ptr() as *const c_char }
+    pub fn capacity(&self) -> usize {
+        self.bytes.capacity()
+    }
+    pub fn len(&self) -> usize {
+        let cstr = unsafe { CStr::from_ptr(self.bytes.as_ptr() as *const i8).to_str() };
+        match cstr {
+            Ok(ref cstr) => cstr.len(),
+            Err(_) => 0
+        }
     }
 }
 
@@ -500,7 +534,7 @@ impl<'ui> Ui<'ui> {
                            -> ColorEdit4<'ui, 'p> {
         ColorEdit4::new(label, value)
     }
-    pub fn input_text<'p>(&self, label: ImStr<'p>, buf: &'p mut str) -> InputText<'ui, 'p> {
+    pub fn input_text<'p>(&self, label: ImStr<'p>, buf: &'p mut ImInput) -> InputText<'ui, 'p> {
         InputText::new(label, buf)
     }
     pub fn input_float<'p>(&self, label: ImStr<'p>, value: &'p mut f32) -> InputFloat<'ui, 'p> {


### PR DESCRIPTION
I was using text input to input a file name in a project I was working on and was finding it a bit unwieldy to use, both in the creation of a `String` suitable to pass to `input_text` and then getting something usable on the Rust side again once it's been edited. In particular, the `String` is fulled with `\0`s which means the length as far as Rust is concerned is effectively the capacity.

For example `println!("\"{}\"", state.text)` would result in `"hello world!  ... (to capacity) ..."`. Passing it to the PathBuf functions would cause a panic due to internal nuls, etc.

To get a string of the correct length for Rust I was passing this `String` to `ffi::CStr`, calling `to_str` on that and then getting the length (of the null terminated string). I thought it would be nicer to try and encapsulate all of this complexity and added the `ImInput` type for this purpose.

What do you think of this approach? Perhaps this functionality would be better off being added to `ImStr`?