### PR TITLE
glium 0.16

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [0.1.0-pre] - 2017-02-06
+
+- Upgrade to glium 0.16
+
 ## [0.0.10] - 2016-08-09
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ default = ["glium"]
 libc = "0.2"
 
 [dependencies.glium]
-version = "0.15"
+version = "0.16"
 default-features = false
 optional = true
 
@@ -26,6 +26,6 @@ path = "imgui-sys"
 gcc = "0.3"
 
 [dev-dependencies.glium]
-version = "0.15"
+version = "0.16"
 features = ["glutin"]
 default-features = false

--- a/imgui-sys/Cargo.toml
+++ b/imgui-sys/Cargo.toml
@@ -16,7 +16,7 @@ bitflags = "0.7"
 libc = "0.2"
 
 [dependencies.glium]
-version = "0.15"
+version = "0.16"
 default-features = false
 optional = true
 


### PR DESCRIPTION
Just updating the glium version. Without this I was getting errors for `GlutinFacade` not implementing `Facade`.