### PR TITLE
Split ImStr to ImStr and ImString

### DIFF
--- a/imgui-glium-renderer/examples/test_window_impl.rs
+++ b/imgui-glium-renderer/examples/test_window_impl.rs
@@ -4,7 +4,6 @@ extern crate imgui;
 extern crate imgui_glium_renderer;
 
 use imgui::*;
-use std::iter::repeat;
 
 use self::support::Support;
 
@@ -31,10 +30,10 @@ struct State {
     no_menu: bool,
     bg_alpha: f32,
     wrap_width: f32,
-    buf: String,
+    buf: ImString,
     item: i32,
     item2: i32,
-    text: String,
+    text: ImString,
     i0: i32,
     f0: f32,
     vec2f: [f32; 2],
@@ -50,13 +49,10 @@ struct State {
 
 impl Default for State {
     fn default() -> Self {
-        let mut buf = "日本語".to_owned();
-        buf.extend(repeat('\0').take(32));
-        buf.truncate(32);
-        let mut text = String::with_capacity(128);
+        let mut buf = ImString::with_capacity(32);
+        buf.push_str("日本語");
+        let mut text = ImString::with_capacity(128);
         text.push_str("Hello, world!");
-        let remaining = text.capacity() - text.len();
-        text.extend(repeat('\0').take(remaining));
         State {
             clear_color: (114.0 / 255.0, 144.0 / 255.0, 154.0 / 255.0, 1.0),
             show_app_metrics: false,

--- a/src/input.rs
+++ b/src/input.rs
@@ -152,10 +152,8 @@ impl<'ui, 'p> InputText<'ui, 'p> {
     pub fn build(self) -> bool {
         unsafe {
             imgui_sys::igInputText(self.label.as_ptr(),
-                                   // TODO: this is evil.
-                                   // Perhaps something else than &mut str is better
                                    self.buf.as_ptr() as *mut i8,
-                                   self.buf.capacity() + 1,
+                                   self.buf.capacity_with_nul(),
                                    self.flags,
                                    None,
                                    ptr::null_mut())

--- a/src/input.rs
+++ b/src/input.rs
@@ -10,7 +10,7 @@ use super::{ImGuiInputTextFlags,
             ImGuiInputTextFlags_CharsDecimal, ImGuiInputTextFlags_CharsHexadecimal,
             ImGuiInputTextFlags_CharsNoBlank, ImGuiInputTextFlags_CharsUppercase,
             ImGuiInputTextFlags_EnterReturnsTrue, ImGuiInputTextFlags_NoHorizontalScroll, ImStr,
-            Ui};
+            ImString, Ui};
 
 macro_rules! impl_text_flags {
     ($InputType:ident) => {
@@ -128,14 +128,14 @@ macro_rules! impl_precision_params {
 
 #[must_use]
 pub struct InputText<'ui, 'p> {
-    label: ImStr<'p>,
-    buf: &'p mut str,
+    label: &'p ImStr,
+    buf: &'p mut ImString,
     flags: ImGuiInputTextFlags,
     _phantom: PhantomData<&'ui Ui<'ui>>,
 }
 
 impl<'ui, 'p> InputText<'ui, 'p> {
-    pub fn new(label: ImStr<'p>, buf: &'p mut str) -> Self {
+    pub fn new(label: &'p ImStr, buf: &'p mut ImString) -> Self {
         InputText {
             label: label,
             buf: buf,
@@ -155,7 +155,7 @@ impl<'ui, 'p> InputText<'ui, 'p> {
                                    // TODO: this is evil.
                                    // Perhaps something else than &mut str is better
                                    self.buf.as_ptr() as *mut i8,
-                                   self.buf.len() as usize,
+                                   self.buf.capacity() + 1,
                                    self.flags,
                                    None,
                                    ptr::null_mut())
@@ -165,7 +165,7 @@ impl<'ui, 'p> InputText<'ui, 'p> {
 
 #[must_use]
 pub struct InputInt<'ui, 'p> {
-    label: ImStr<'p>,
+    label: &'p ImStr,
     value: &'p mut i32,
     step: i32,
     step_fast: i32,
@@ -174,7 +174,7 @@ pub struct InputInt<'ui, 'p> {
 }
 
 impl<'ui, 'p> InputInt<'ui, 'p> {
-    pub fn new(label: ImStr<'p>, value: &'p mut i32) -> Self {
+    pub fn new(label: &'p ImStr, value: &'p mut i32) -> Self {
         InputInt {
             label: label,
             value: value,
@@ -201,7 +201,7 @@ impl<'ui, 'p> InputInt<'ui, 'p> {
 
 #[must_use]
 pub struct InputFloat<'ui, 'p> {
-    label: ImStr<'p>,
+    label: &'p ImStr,
     value: &'p mut f32,
     step: f32,
     step_fast: f32,
@@ -211,7 +211,7 @@ pub struct InputFloat<'ui, 'p> {
 }
 
 impl<'ui, 'p> InputFloat<'ui, 'p> {
-    pub fn new(label: ImStr<'p>, value: &'p mut f32) -> Self {
+    pub fn new(label: &'p ImStr, value: &'p mut f32) -> Self {
         InputFloat {
             label: label,
             value: value,
@@ -243,7 +243,7 @@ macro_rules! impl_input_floatn {
     ($InputFloatN:ident, $N:expr, $igInputFloatN:ident) => {
         #[must_use]
         pub struct $InputFloatN<'ui, 'p> {
-            label: ImStr<'p>,
+            label: &'p ImStr,
             value: &'p mut [f32;$N],
             decimal_precision: i32,
             flags: ImGuiInputTextFlags,
@@ -251,7 +251,7 @@ macro_rules! impl_input_floatn {
         }
 
         impl<'ui, 'p> $InputFloatN<'ui, 'p> {
-            pub fn new(label: ImStr<'p>, value: &'p mut [f32;$N]) -> Self {
+            pub fn new(label: &'p ImStr, value: &'p mut [f32;$N]) -> Self {
                 $InputFloatN {
                     label: label,
                     value: value,
@@ -285,14 +285,14 @@ macro_rules! impl_input_intn {
     ($InputIntN:ident, $N:expr, $igInputIntN:ident) => {
         #[must_use]
         pub struct $InputIntN<'ui, 'p> {
-            label: ImStr<'p>,
+            label: &'p ImStr,
             value: &'p mut [i32;$N],
             flags: ImGuiInputTextFlags,
             _phantom: PhantomData<&'ui Ui<'ui>>
         }
 
         impl<'ui, 'p> $InputIntN<'ui, 'p> {
-            pub fn new(label: ImStr<'p>, value: &'p mut [i32;$N]) -> Self {
+            pub fn new(label: &'p ImStr, value: &'p mut [i32;$N]) -> Self {
                 $InputIntN {
                     label: label,
                     value: value,
@@ -321,13 +321,13 @@ impl_input_intn!(InputInt4, 4, igInputInt4);
 
 #[must_use]
 pub struct ColorEdit3<'ui, 'p> {
-    label: ImStr<'p>,
+    label: &'p ImStr,
     value: &'p mut [f32; 3],
     _phantom: PhantomData<&'ui Ui<'ui>>,
 }
 
 impl<'ui, 'p> ColorEdit3<'ui, 'p> {
-    pub fn new(label: ImStr<'p>, value: &'p mut [f32; 3]) -> Self {
+    pub fn new(label: &'p ImStr, value: &'p mut [f32; 3]) -> Self {
         ColorEdit3 {
             label: label,
             value: value,
@@ -342,14 +342,14 @@ impl<'ui, 'p> ColorEdit3<'ui, 'p> {
 
 #[must_use]
 pub struct ColorEdit4<'ui, 'p> {
-    label: ImStr<'p>,
+    label: &'p ImStr,
     value: &'p mut [f32; 4],
     show_alpha: bool,
     _phantom: PhantomData<&'ui Ui<'ui>>,
 }
 
 impl<'ui, 'p> ColorEdit4<'ui, 'p> {
-    pub fn new(label: ImStr<'p>, value: &'p mut [f32; 4]) -> Self {
+    pub fn new(label: &'p ImStr, value: &'p mut [f32; 4]) -> Self {
         ColorEdit4 {
             label: label,
             value: value,

--- a/src/menus.rs
+++ b/src/menus.rs
@@ -6,13 +6,13 @@ use super::{ImStr, Ui};
 
 #[must_use]
 pub struct Menu<'ui, 'p> {
-    label: ImStr<'p>,
+    label: &'p ImStr,
     enabled: bool,
     _phantom: PhantomData<&'ui Ui<'ui>>,
 }
 
 impl<'ui, 'p> Menu<'ui, 'p> {
-    pub fn new(label: ImStr<'p>) -> Self {
+    pub fn new(label: &'p ImStr) -> Self {
         Menu {
             label: label,
             enabled: true,
@@ -35,15 +35,15 @@ impl<'ui, 'p> Menu<'ui, 'p> {
 
 #[must_use]
 pub struct MenuItem<'ui, 'p> {
-    label: ImStr<'p>,
-    shortcut: Option<ImStr<'p>>,
+    label: &'p ImStr,
+    shortcut: Option<&'p ImStr>,
     selected: Option<&'p mut bool>,
     enabled: bool,
     _phantom: PhantomData<&'ui Ui<'ui>>,
 }
 
 impl<'ui, 'p> MenuItem<'ui, 'p> {
-    pub fn new(label: ImStr<'p>) -> Self {
+    pub fn new(label: &'p ImStr) -> Self {
         MenuItem {
             label: label,
             shortcut: None,
@@ -53,7 +53,7 @@ impl<'ui, 'p> MenuItem<'ui, 'p> {
         }
     }
     #[inline]
-    pub fn shortcut(mut self, shortcut: ImStr<'p>) -> Self {
+    pub fn shortcut(mut self, shortcut: &'p ImStr) -> Self {
         self.shortcut = Some(shortcut);
         self
     }

--- a/src/plothistogram.rs
+++ b/src/plothistogram.rs
@@ -6,17 +6,17 @@ use super::{ImStr, ImVec2};
 
 #[must_use]
 pub struct PlotHistogram<'p> {
-    label: ImStr<'p>,
+    label: &'p ImStr,
     values: &'p [f32],
     values_offset: usize,
-    overlay_text: Option<ImStr<'p>>,
+    overlay_text: Option<&'p ImStr>,
     scale_min: f32,
     scale_max: f32,
     graph_size: ImVec2,
 }
 
 impl<'p> PlotHistogram<'p> {
-    pub fn new(label: ImStr<'p>, values: &'p [f32]) -> Self {
+    pub fn new(label: &'p ImStr, values: &'p [f32]) -> Self {
         PlotHistogram {
             label: label,
             values: values,
@@ -35,7 +35,7 @@ impl<'p> PlotHistogram<'p> {
     }
 
     #[inline]
-    pub fn overlay_text(mut self, overlay_text: ImStr<'p>) -> Self {
+    pub fn overlay_text(mut self, overlay_text: &'p ImStr) -> Self {
         self.overlay_text = Some(overlay_text);
         self
     }

--- a/src/plotlines.rs
+++ b/src/plotlines.rs
@@ -5,17 +5,17 @@ use std::os::raw::c_float;
 use super::{ImStr, ImVec2};
 #[must_use]
 pub struct PlotLines<'p> {
-    label: ImStr<'p>,
+    label: &'p ImStr,
     values: &'p [f32],
     values_offset: usize,
-    overlay_text: Option<ImStr<'p>>,
+    overlay_text: Option<&'p ImStr>,
     scale_min: f32,
     scale_max: f32,
     graph_size: ImVec2,
 }
 
 impl<'p> PlotLines<'p> {
-    pub fn new(label: ImStr<'p>, values: &'p [f32]) -> Self {
+    pub fn new(label: &'p ImStr, values: &'p [f32]) -> Self {
         PlotLines {
             label: label,
             values: values,
@@ -34,7 +34,7 @@ impl<'p> PlotLines<'p> {
     }
 
     #[inline]
-    pub fn overlay_text(mut self, overlay_text: ImStr<'p>) -> Self {
+    pub fn overlay_text(mut self, overlay_text: &'p ImStr) -> Self {
         self.overlay_text = Some(overlay_text);
         self
     }

--- a/src/progressbar.rs
+++ b/src/progressbar.rs
@@ -10,7 +10,7 @@ use super::{ImStr, ImVec2};
 pub struct ProgressBar<'p> {
     fraction: f32,
     size: ImVec2,
-    overlay_text: Option<ImStr<'p>>,
+    overlay_text: Option<&'p ImStr>,
 }
 
 impl<'p> ProgressBar<'p> {
@@ -29,7 +29,7 @@ impl<'p> ProgressBar<'p> {
 
     /// Sets an optional text that will be drawn over the progress bar.
     #[inline]
-    pub fn overlay_text(mut self, overlay_text: ImStr<'p>) -> Self {
+    pub fn overlay_text(mut self, overlay_text: &'p ImStr) -> Self {
         self.overlay_text = Some(overlay_text);
         self
     }

--- a/src/sliders.rs
+++ b/src/sliders.rs
@@ -7,16 +7,16 @@ use super::{ImStr, Ui};
 
 #[must_use]
 pub struct SliderInt<'ui, 'p> {
-    label: ImStr<'p>,
+    label: &'p ImStr,
     value: &'p mut i32,
     min: i32,
     max: i32,
-    display_format: ImStr<'p>,
+    display_format: &'p ImStr,
     _phantom: PhantomData<&'ui Ui<'ui>>,
 }
 
 impl<'ui, 'p> SliderInt<'ui, 'p> {
-    pub fn new(label: ImStr<'p>, value: &'p mut i32, min: i32, max: i32) -> Self {
+    pub fn new(label: &'p ImStr, value: &'p mut i32, min: i32, max: i32) -> Self {
         SliderInt {
             label: label,
             value: value,
@@ -27,7 +27,7 @@ impl<'ui, 'p> SliderInt<'ui, 'p> {
         }
     }
     #[inline]
-    pub fn display_format(mut self, display_format: ImStr<'p>) -> Self {
+    pub fn display_format(mut self, display_format: &'p ImStr) -> Self {
         self.display_format = display_format;
         self
     }
@@ -46,16 +46,16 @@ macro_rules! impl_slider_intn {
     ($SliderIntN:ident, $N:expr, $igSliderIntN:ident) => {
         #[must_use]
         pub struct $SliderIntN<'ui, 'p> {
-            label: ImStr<'p>,
+            label: &'p ImStr,
             value: &'p mut [i32; $N],
             min: i32,
             max: i32,
-            display_format: ImStr<'p>,
+            display_format: &'p ImStr,
             _phantom: PhantomData<&'ui Ui<'ui>>,
         }
 
         impl<'ui, 'p> $SliderIntN<'ui, 'p> {
-            pub fn new(label: ImStr<'p>, value: &'p mut [i32; $N], min: i32, max: i32) -> Self {
+            pub fn new(label: &'p ImStr, value: &'p mut [i32; $N], min: i32, max: i32) -> Self {
                 $SliderIntN {
                     label: label,
                     value: value,
@@ -66,7 +66,7 @@ macro_rules! impl_slider_intn {
                 }
             }
             #[inline]
-            pub fn display_format(mut self, display_format: ImStr<'p>) -> Self {
+            pub fn display_format(mut self, display_format: &'p ImStr) -> Self {
                 self.display_format = display_format;
                 self
             }
@@ -90,17 +90,17 @@ impl_slider_intn!(SliderInt4, 4, igSliderInt4);
 
 #[must_use]
 pub struct SliderFloat<'ui, 'p> {
-    label: ImStr<'p>,
+    label: &'p ImStr,
     value: &'p mut f32,
     min: f32,
     max: f32,
-    display_format: ImStr<'p>,
+    display_format: &'p ImStr,
     power: f32,
     _phantom: PhantomData<&'ui Ui<'ui>>,
 }
 
 impl<'ui, 'p> SliderFloat<'ui, 'p> {
-    pub fn new(label: ImStr<'p>, value: &'p mut f32, min: f32, max: f32) -> Self {
+    pub fn new(label: &'p ImStr, value: &'p mut f32, min: f32, max: f32) -> Self {
         SliderFloat {
             label: label,
             value: value,
@@ -112,7 +112,7 @@ impl<'ui, 'p> SliderFloat<'ui, 'p> {
         }
     }
     #[inline]
-    pub fn display_format(mut self, display_format: ImStr<'p>) -> Self {
+    pub fn display_format(mut self, display_format: &'p ImStr) -> Self {
         self.display_format = display_format;
         self
     }
@@ -137,17 +137,17 @@ macro_rules! impl_slider_floatn {
     ($SliderFloatN:ident, $N:expr, $igSliderFloatN:ident) => {
         #[must_use]
         pub struct $SliderFloatN<'ui, 'p> {
-            label: ImStr<'p>,
+            label: &'p ImStr,
             value: &'p mut [f32; $N],
             min: f32,
             max: f32,
-            display_format: ImStr<'p>,
+            display_format: &'p ImStr,
             power: f32,
             _phantom: PhantomData<&'ui Ui<'ui>>,
         }
 
         impl<'ui, 'p> $SliderFloatN<'ui, 'p> {
-            pub fn new(label: ImStr<'p>, value: &'p mut [f32; $N], min: f32, max: f32) -> Self {
+            pub fn new(label: &'p ImStr, value: &'p mut [f32; $N], min: f32, max: f32) -> Self {
                 $SliderFloatN {
                     label: label,
                     value: value,
@@ -159,7 +159,7 @@ macro_rules! impl_slider_floatn {
                 }
             }
             #[inline]
-            pub fn display_format(mut self, display_format: ImStr<'p>) -> Self {
+            pub fn display_format(mut self, display_format: &'p ImStr) -> Self {
                 self.display_format = display_format;
                 self
             }

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,0 +1,122 @@
+use std::borrow::Borrow;
+use std::ffi::{CStr, CString, NulError};
+use std::fmt;
+use std::mem;
+use std::ops::Deref;
+use std::os::raw::c_char;
+use std::str;
+
+#[derive(Clone, Default, Hash, Ord, Eq, PartialOrd, PartialEq)]
+pub struct ImString(Vec<u8>);
+
+impl ImString {
+    pub fn new<T: Into<String>>(t: T) -> Result<ImString, NulError> {
+        CString::new(t.into()).map(|cstring| ImString(cstring.into_bytes_with_nul()))
+    }
+    pub fn with_capacity(capacity: usize) -> ImString {
+        let mut v = Vec::with_capacity(capacity + 1);
+        v.push(b'\0');
+        ImString(v)
+    }
+    pub unsafe fn from_string_unchecked(s: String) -> ImString {
+        ImString::from_vec_unchecked(s.into())
+    }
+    pub unsafe fn from_vec_unchecked(mut v: Vec<u8>) -> ImString {
+        v.push(b'\0');
+        ImString(v)
+    }
+    pub fn clear(&mut self) {
+        self.0.clear();
+        self.0.push(b'\0');
+    }
+    pub fn push_str(&mut self, string: &str) {
+        self.0.pop();
+        self.0.extend_from_slice(string.as_bytes());
+        self.0.push(b'\0');
+    }
+    pub fn capacity(&self) -> usize { self.0.capacity() - 1 }
+    pub fn reserve(&mut self, additional: usize) {
+        self.0.reserve(additional);
+    }
+    pub fn reserve_exact(&mut self, additional: usize) {
+        self.0.reserve_exact(additional);
+    }
+}
+
+impl AsRef<ImStr> for ImString {
+    fn as_ref(&self) -> &ImStr { self }
+}
+
+impl Borrow<ImStr> for ImString {
+    fn borrow(&self) -> &ImStr { self }
+}
+
+impl fmt::Debug for ImString {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let s: &str = self;
+        fmt::Debug::fmt(s, f)
+    }
+}
+
+impl Deref for ImString {
+    type Target = ImStr;
+    fn deref(&self) -> &ImStr {
+        // as_ptr() is used, because we need to look at the bytes to figure out the length
+        // self.0.len() is incorrect, because there might be more than one nul byte in the end
+        unsafe { mem::transmute(CStr::from_ptr(self.0.as_ptr() as *const c_char)) }
+    }
+}
+
+impl<'a> From<&'a ImStr> for ImString {
+    fn from(value: &'a ImStr) -> ImString { value.to_owned() }
+}
+
+#[derive(Hash)]
+pub struct ImStr(CStr);
+
+impl<'a> Default for &'a ImStr {
+    fn default() -> &'a ImStr {
+        static SLICE: &'static [u8] = &[0];
+        unsafe { ImStr::from_bytes_unchecked(SLICE) }
+    }
+}
+
+impl fmt::Debug for ImStr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, f)
+    }
+}
+
+impl ImStr {
+    pub unsafe fn from_bytes_unchecked<'a>(bytes: &'a [u8]) -> &'a ImStr {
+        mem::transmute(bytes)
+    }
+    pub fn as_ptr(&self) -> *const c_char { self.0.as_ptr() as *const c_char }
+    pub fn to_str(&self) -> &str {
+        unsafe { str::from_utf8_unchecked(&self.as_bytes()) }
+    }
+}
+
+impl<'a> Into<&'a CStr> for &'a ImStr {
+    fn into(self) -> &'a CStr { &self.0 }
+}
+
+impl AsRef<CStr> for ImStr {
+    fn as_ref(&self) -> &CStr { &self.0 }
+}
+
+impl AsRef<ImStr> for ImStr {
+    fn as_ref(&self) -> &ImStr { self }
+}
+
+impl ToOwned for ImStr {
+    type Owned = ImString;
+    fn to_owned(&self) -> ImString { ImString(self.0.to_owned().into_bytes()) }
+}
+
+impl Deref for ImStr {
+    type Target = str;
+    fn deref(&self) -> &str {
+        unsafe { str::from_utf8_unchecked(self.0.to_bytes()) }
+    }
+}

--- a/src/string.rs
+++ b/src/string.rs
@@ -35,6 +35,7 @@ impl ImString {
         self.0.push(b'\0');
     }
     pub fn capacity(&self) -> usize { self.0.capacity() - 1 }
+    pub fn capacity_with_nul(&self) -> usize { self.0.capacity() }
     pub fn reserve(&mut self, additional: usize) {
         self.0.reserve(additional);
     }

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -8,15 +8,15 @@ use super::{ImGuiSetCond, ImGuiTreeNodeFlags, ImGuiTreeNodeFlags_Bullet,
 
 #[must_use]
 pub struct TreeNode<'ui, 'p> {
-    id: ImStr<'p>,
-    label: Option<ImStr<'p>>,
+    id: &'p ImStr,
+    label: Option<&'p ImStr>,
     opened: bool,
     opened_cond: ImGuiSetCond,
     _phantom: PhantomData<&'ui Ui<'ui>>,
 }
 
 impl<'ui, 'p> TreeNode<'ui, 'p> {
-    pub fn new(id: ImStr<'p>) -> Self {
+    pub fn new(id: &'p ImStr) -> Self {
         TreeNode {
             id: id,
             label: None,
@@ -26,7 +26,7 @@ impl<'ui, 'p> TreeNode<'ui, 'p> {
         }
     }
     #[inline]
-    pub fn label(mut self, label: ImStr<'p>) -> Self {
+    pub fn label(mut self, label: &'p ImStr) -> Self {
         self.label = Some(label);
         self
     }
@@ -54,7 +54,7 @@ impl<'ui, 'p> TreeNode<'ui, 'p> {
 
 #[must_use]
 pub struct CollapsingHeader<'ui, 'p> {
-    label: ImStr<'p>,
+    label: &'p ImStr,
     // Some flags are automatically set in ImGui::CollapsingHeader, so
     // we only support a sensible subset here
     flags: ImGuiTreeNodeFlags,
@@ -62,7 +62,7 @@ pub struct CollapsingHeader<'ui, 'p> {
 }
 
 impl<'ui, 'p> CollapsingHeader<'ui, 'p> {
-    pub fn new(label: ImStr<'p>) -> Self {
+    pub fn new(label: &'p ImStr) -> Self {
         CollapsingHeader {
             label: label,
             flags: ImGuiTreeNodeFlags::empty(),

--- a/src/window.rs
+++ b/src/window.rs
@@ -18,7 +18,7 @@ pub struct Window<'ui, 'p> {
     pos_cond: ImGuiSetCond,
     size: (f32, f32),
     size_cond: ImGuiSetCond,
-    name: ImStr<'p>,
+    name: &'p ImStr,
     opened: Option<&'p mut bool>,
     bg_alpha: f32,
     flags: ImGuiWindowFlags,
@@ -26,7 +26,7 @@ pub struct Window<'ui, 'p> {
 }
 
 impl<'ui, 'p> Window<'ui, 'p> {
-    pub fn new(name: ImStr<'p>) -> Window<'ui, 'p> {
+    pub fn new(name: &'p ImStr) -> Window<'ui, 'p> {
         Window {
             pos: (0.0, 0.0),
             pos_cond: ImGuiSetCond::empty(),


### PR DESCRIPTION
It might be better to use the utf8-cstr crate, but it doesn't have the
owned<->borrowed duality, so it would be used as an implementation
detail only.