### PR TITLE
Changed string pointer casts to be inferred for cross-compiling to ARM.

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -152,7 +152,7 @@ impl<'ui, 'p> InputText<'ui, 'p> {
     pub fn build(self) -> bool {
         unsafe {
             imgui_sys::igInputText(self.label.as_ptr(),
-                                   self.buf.as_ptr() as *mut i8,
+                                   self.buf.as_ptr() as *mut _,
                                    self.buf.capacity_with_nul(),
                                    self.flags,
                                    None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,7 +235,7 @@ impl ImGui {
         string.push(character);
         string.push('\0');
         unsafe {
-            imgui_sys::ImGuiIO_AddInputCharactersUTF8(string.as_ptr() as *const i8);
+            imgui_sys::ImGuiIO_AddInputCharactersUTF8(string.as_ptr() as *const _);
         }
     }
     pub fn get_time(&self) -> f32 { unsafe { imgui_sys::igGetTime() } }


### PR DESCRIPTION
I can into an issue while cross-compiling to arm-unknown-linux-gnueabihf where the pointer types for strings weren't matching as ARM expects u8 instead of i8. 