### PR TITLE
Initial window support, looking for ideas/help

### DIFF
--- a/src/child_frame.rs
+++ b/src/child_frame.rs
@@ -1,0 +1,126 @@
+use std::mem::transmute;
+
+use ImVec2;
+use ImGuiWindowFlags;
+
+use super::{ImGuiWindowFlags_NoTitleBar, ImGuiWindowFlags_NoResize, ImGuiWindowFlags_NoMove,
+            ImGuiWindowFlags_NoScrollbar, ImGuiWindowFlags_NoScrollWithMouse,
+            ImGuiWindowFlags_NoCollapse, ImGuiWindowFlags_AlwaysAutoResize,
+            ImGuiWindowFlags_ShowBorders, ImGuiWindowFlags_NoSavedSettings,
+            ImGuiWindowFlags_NoInputs, ImGuiWindowFlags_MenuBar,
+            ImGuiWindowFlags_HorizontalScrollbar, ImGuiWindowFlags_NoFocusOnAppearing,
+            ImGuiWindowFlags_NoBringToFrontOnFocus, ImGuiWindowFlags_AlwaysVerticalScrollbar,
+            ImGuiWindowFlags_AlwaysHorizontalScrollbar, ImGuiWindowFlags_AlwaysUseWindowPadding};
+
+#[must_use]
+pub struct ChildFrame {
+    pub size: ImVec2,
+    pub flags: ImGuiWindowFlags,
+}
+
+impl ChildFrame {
+    pub fn new(size: ImVec2) -> ChildFrame {
+        let empty_flag: ImGuiWindowFlags = unsafe { transmute::<i32, ImGuiWindowFlags>(0) };
+        ChildFrame {
+            size: size,
+            flags: empty_flag,
+        }
+    }
+    #[inline]
+    pub fn show_title(mut self, value: bool) -> Self {
+        self.flags.set(ImGuiWindowFlags_NoTitleBar, !value);
+        self
+    }
+    #[inline]
+    pub fn resizable(mut self, value: bool) -> Self {
+        self.flags.set(ImGuiWindowFlags_NoResize, !value);
+        self
+    }
+    #[inline]
+    pub fn movable(mut self, value: bool) -> Self {
+        self.flags.set(ImGuiWindowFlags_NoMove, !value);
+        self
+    }
+    #[inline]
+    pub fn show_scrollbar(mut self, value: bool) -> Self {
+        self.flags.set(ImGuiWindowFlags_NoScrollbar, !value);
+        self
+    }
+    #[inline]
+    pub fn show_scrollbar_with_mouse(mut self, value: bool) -> Self {
+        self.flags.set(ImGuiWindowFlags_NoScrollWithMouse, !value);
+        self
+    }
+    #[inline]
+    pub fn collapsible(mut self, value: bool) -> Self {
+        self.flags.set(ImGuiWindowFlags_NoCollapse, !value);
+        self
+    }
+    #[inline]
+    pub fn always_resizable(mut self, value: bool) -> Self {
+        self.flags.set(ImGuiWindowFlags_AlwaysAutoResize, value);
+        self
+    }
+    #[inline]
+    pub fn show_borders(mut self, value: bool) -> Self {
+        self.flags.set(ImGuiWindowFlags_ShowBorders, value);
+        self
+    }
+    #[inline]
+    pub fn save_settings(mut self, value: bool) -> Self {
+        self.flags.set(ImGuiWindowFlags_NoSavedSettings, !value);
+        self
+    }
+    #[inline]
+    pub fn input_allow(mut self, value: bool) -> Self {
+        self.flags.set(ImGuiWindowFlags_NoInputs, !value);
+        self
+    }
+    #[inline]
+    pub fn show_menu(mut self, value: bool) -> Self {
+        self.flags.set(ImGuiWindowFlags_MenuBar, value);
+        self
+    }
+    #[inline]
+    pub fn scrollbar_horizontal(mut self, value: bool) -> Self {
+        self.flags.set(ImGuiWindowFlags_HorizontalScrollbar, value);
+        self
+    }
+    #[inline]
+    pub fn focus_on_appearing(mut self, value: bool) -> Self {
+        self.flags.set(ImGuiWindowFlags_NoFocusOnAppearing, !value);
+        self
+    }
+    #[inline]
+    pub fn bring_to_front_on_focus(mut self, value: bool) -> Self {
+        self.flags.set(
+            ImGuiWindowFlags_NoBringToFrontOnFocus,
+            !value,
+        );
+        self
+    }
+    #[inline]
+    pub fn always_show_vertical_scroll_bar(mut self, value: bool) -> Self {
+        self.flags.set(
+            ImGuiWindowFlags_AlwaysVerticalScrollbar,
+            value,
+        );
+        self
+    }
+    #[inline]
+    pub fn always_show_horizontal_scroll_bar(mut self, value: bool) -> Self {
+        self.flags.set(
+            ImGuiWindowFlags_AlwaysHorizontalScrollbar,
+            value,
+        );
+        self
+    }
+    #[inline]
+    pub fn always_use_window_padding(mut self, value: bool) -> Self {
+        self.flags.set(
+            ImGuiWindowFlags_AlwaysUseWindowPadding,
+            value,
+        );
+        self
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub use imgui_sys::{ImDrawIdx, ImDrawVert, ImGuiInputTextFlags, ImGuiInputTextFl
                     ImGuiWindowFlags_NoSavedSettings, ImGuiWindowFlags_NoScrollWithMouse,
                     ImGuiWindowFlags_NoScrollbar, ImGuiWindowFlags_NoTitleBar,
                     ImGuiWindowFlags_ShowBorders, ImVec2, ImVec4};
+pub use child_frame::ChildFrame;
 pub use input::{ColorEdit3, ColorEdit4, InputFloat, InputFloat2, InputFloat3, InputFloat4,
                 InputInt, InputInt2, InputInt3, InputInt4, InputText};
 pub use menus::{Menu, MenuItem};
@@ -48,6 +49,7 @@ pub use style::StyleVar;
 pub use trees::{CollapsingHeader, TreeNode};
 pub use window::Window;
 
+mod child_frame;
 mod input;
 mod menus;
 mod plothistogram;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -755,3 +755,68 @@ impl<'ui> Ui<'ui> {
     /// ```
     pub fn progress_bar<'p>(&self, fraction: f32) -> ProgressBar<'p> { ProgressBar::new(fraction) }
 }
+
+impl<'ui> Ui<'ui> {
+    fn push_style_var(&self, style_var: StyleVar) {
+        use StyleVar::*;
+        use imgui_sys::{igPushStyleVar, igPushStyleVarVec};
+        match style_var {
+            Alpha(v) => unsafe { igPushStyleVar(ImGuiStyleVar::Alpha, v) },
+            WindowPadding(v) => unsafe { igPushStyleVarVec(ImGuiStyleVar::WindowPadding, v) },
+            WindowRounding(v) => unsafe { igPushStyleVar(ImGuiStyleVar::WindowRounding, v) },
+            WindowMinSize(v) => unsafe { igPushStyleVarVec(ImGuiStyleVar::WindowMinSize, v) },
+            ChildWindowRounding(v) => unsafe { igPushStyleVar(ImGuiStyleVar::ChildWindowRounding, v) },
+            FramePadding(v) => unsafe { igPushStyleVarVec(ImGuiStyleVar::FramePadding, v) },
+            FrameRounding(v) => unsafe { igPushStyleVar(ImGuiStyleVar::FrameRounding, v) },
+            ItemSpacing(v) => unsafe { igPushStyleVarVec(ImGuiStyleVar::ItemSpacing, v) },
+            ItemInnerSpacing(v) => unsafe { igPushStyleVarVec(ImGuiStyleVar::ItemInnerSpacing, v) },
+            IndentSpacing(v) => unsafe { igPushStyleVar(ImGuiStyleVar::IndentSpacing, v) },
+            GrabMinSize(v) => unsafe { igPushStyleVar(ImGuiStyleVar::GrabMinSize, v) },
+            ButtonTextAlign(v) => unsafe { igPushStyleVarVec(ImGuiStyleVar::ButtonTextAlign, v) }
+        }
+    }
+
+    /// Runs a function after temporarily pushing a value to the style stack.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// # use imgui::*;
+    /// # let mut imgui = ImGui::init();
+    /// # let ui = imgui.frame((0, 0), (0, 0), 0.1);
+    /// ui.with_style_var(StyleVar::Alpha(0.2), || {
+    ///     ui.text(im_str!("AB"));
+    /// });
+    /// ui.with_style_var(StyleVar::Alpha(0.4), || {
+    ///     ui.text(im_str!("CD"));
+    /// });
+    /// ```
+    pub fn with_style_var<F: FnOnce()>(&self, style_var: StyleVar, f: F) {
+        self.push_style_var(style_var);
+        f();
+        unsafe { imgui_sys::igPopStyleVar(1) }
+    }
+
+    /// Runs a function after temporarily pushing an array of values into the stack. Supporting
+    /// multiple is also easy since you can freely mix and match them in a safe manner.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// # use imgui::*;
+    /// # let mut imgui = ImGui::init();
+    /// # let ui = imgui.frame((0, 0), (0, 0), 0.1);
+    /// # let styles = [StyleVar::Alpha(0.2), StyleVar::WindowPadding(ImVec2::new(1.0, 1.0))];
+    /// ui.with_style_vars(&styles, || {
+    ///     ui.text(im_str!("A"));
+    ///     ui.text(im_str!("B"));
+    ///     ui.text(im_str!("C"));
+    ///     ui.text(im_str!("D"));
+    /// });
+    /// ```
+    pub fn with_style_vars<F: FnOnce()>(&self, style_vars: &[StyleVar], f: F) {
+        for &style_var in style_vars {
+            self.push_style_var(style_var);
+        }
+        f();
+        unsafe { imgui_sys::igPopStyleVar(style_vars.len() as i32) };
+    }
+}

--- a/src/style.rs
+++ b/src/style.rs
@@ -20,29 +20,6 @@ pub enum StyleVar {
     ButtonTextAlign(ImVec2),
 }
 
-trait IntoStyleVars {
-    fn into_style_var(self) -> StyleVar;
-}
-
-impl IntoStyleVars for StyleVar {
-    fn into_style_var(self) -> StyleVar {
-        match self {
-            StyleVar::Alpha(v) => StyleVar::Alpha(v),
-            StyleVar::WindowPadding(v) => StyleVar::WindowPadding(v),
-            StyleVar::WindowRounding(v) => StyleVar::WindowRounding(v),
-            StyleVar::WindowMinSize(v) => StyleVar::WindowMinSize(v),
-            StyleVar::ChildWindowRounding(v) => StyleVar::ChildWindowRounding(v),
-            StyleVar::FramePadding(v) => StyleVar::FramePadding(v),
-            StyleVar::FrameRounding(v) => StyleVar::FrameRounding(v),
-            StyleVar::ItemSpacing(v) => StyleVar::ItemSpacing(v),
-            StyleVar::ItemInnerSpacing(v) => StyleVar::ItemInnerSpacing(v),
-            StyleVar::IndentSpacing(v) => StyleVar::IndentSpacing(v),
-            StyleVar::GrabMinSize(v) => StyleVar::GrabMinSize(v),
-            StyleVar::ButtonTextAlign(v) => StyleVar::ButtonTextAlign(v)
-        }
-   }
-}
-
 impl<'ui> Ui<'ui> {
     fn push_style_var(&self, style_var: StyleVar) {
         use StyleVar::*;

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,5 +1,3 @@
-extern crate imgui_sys;
-
 use ImVec2;
 
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,0 +1,109 @@
+extern crate imgui_sys;
+
+use ImVec2;
+use Ui;
+use imgui_sys::ImGuiStyleVar;
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum StyleVar {
+    Alpha(f32),
+    WindowPadding(ImVec2),
+    WindowRounding(f32),
+    WindowMinSize(ImVec2),
+    ChildWindowRounding(f32),
+    FramePadding(ImVec2),
+    FrameRounding(f32),
+    ItemSpacing(ImVec2),
+    ItemInnerSpacing(ImVec2),
+    IndentSpacing(f32),
+    GrabMinSize(f32),
+    ButtonTextAlign(ImVec2),
+}
+
+trait IntoStyleVars {
+    fn into_style_var(self) -> StyleVar;
+}
+
+impl IntoStyleVars for StyleVar {
+    fn into_style_var(self) -> StyleVar {
+        match self {
+            StyleVar::Alpha(v) => StyleVar::Alpha(v),
+            StyleVar::WindowPadding(v) => StyleVar::WindowPadding(v),
+            StyleVar::WindowRounding(v) => StyleVar::WindowRounding(v),
+            StyleVar::WindowMinSize(v) => StyleVar::WindowMinSize(v),
+            StyleVar::ChildWindowRounding(v) => StyleVar::ChildWindowRounding(v),
+            StyleVar::FramePadding(v) => StyleVar::FramePadding(v),
+            StyleVar::FrameRounding(v) => StyleVar::FrameRounding(v),
+            StyleVar::ItemSpacing(v) => StyleVar::ItemSpacing(v),
+            StyleVar::ItemInnerSpacing(v) => StyleVar::ItemInnerSpacing(v),
+            StyleVar::IndentSpacing(v) => StyleVar::IndentSpacing(v),
+            StyleVar::GrabMinSize(v) => StyleVar::GrabMinSize(v),
+            StyleVar::ButtonTextAlign(v) => StyleVar::ButtonTextAlign(v)
+        }
+   }
+}
+
+impl<'ui> Ui<'ui> {
+    fn push_style_var(&self, style_var: StyleVar) {
+        use StyleVar::*;
+        use imgui_sys::{igPushStyleVar, igPushStyleVarVec};
+        match style_var {
+            Alpha(v) => unsafe { igPushStyleVar(ImGuiStyleVar::Alpha, v) },
+            WindowPadding(v) => unsafe { igPushStyleVarVec(ImGuiStyleVar::WindowPadding, v) },
+            WindowRounding(v) => unsafe { igPushStyleVar(ImGuiStyleVar::WindowRounding, v) },
+            WindowMinSize(v) => unsafe { igPushStyleVarVec(ImGuiStyleVar::WindowMinSize, v) },
+            ChildWindowRounding(v) => unsafe { igPushStyleVar(ImGuiStyleVar::ChildWindowRounding, v) },
+            FramePadding(v) => unsafe { igPushStyleVarVec(ImGuiStyleVar::FramePadding, v) },
+            FrameRounding(v) => unsafe { igPushStyleVar(ImGuiStyleVar::FrameRounding, v) },
+            ItemSpacing(v) => unsafe { igPushStyleVarVec(ImGuiStyleVar::ItemSpacing, v) },
+            ItemInnerSpacing(v) => unsafe { igPushStyleVarVec(ImGuiStyleVar::ItemInnerSpacing, v) },
+            IndentSpacing(v) => unsafe { igPushStyleVar(ImGuiStyleVar::IndentSpacing, v) },
+            GrabMinSize(v) => unsafe { igPushStyleVar(ImGuiStyleVar::GrabMinSize, v) },
+            ButtonTextAlign(v) => unsafe { igPushStyleVarVec(ImGuiStyleVar::ButtonTextAlign, v) }
+        }
+    }
+
+    /// Runs a function after temporarily pushing a value to the style stack.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// # use imgui::*;
+    /// # let mut imgui = ImGui::init();
+    /// # let ui = imgui.frame((0, 0), (0, 0), 0.1);
+    /// ui.with_style_var(StyleVar::Alpha(0.2), || {
+    ///     ui.text(im_str!("AB"));
+    /// });
+    /// ui.with_style_var(StyleVar::Alpha(0.4), || {
+    ///     ui.text(im_str!("CD"));
+    /// });
+    /// ```
+    pub fn with_style_var<F: FnOnce()>(&self, style_var: StyleVar, f: F) {
+        self.push_style_var(style_var);
+        f();
+        unsafe { imgui_sys::igPopStyleVar(1) }
+    }
+
+    /// Runs a function after temporarily pushing an array of values into the stack. Supporting
+    /// multiple is also easy since you can freely mix and match them in a safe manner.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// # use imgui::*;
+    /// # let mut imgui = ImGui::init();
+    /// # let ui = imgui.frame((0, 0), (0, 0), 0.1);
+    /// # let styles = [StyleVar::Alpha(0.2), StyleVar::WindowPadding(ImVec2::new(1.0, 1.0))];
+    /// ui.with_style_vars(&styles, || {
+    ///     ui.text(im_str!("A"));
+    ///     ui.text(im_str!("B"));
+    ///     ui.text(im_str!("C"));
+    ///     ui.text(im_str!("D"));
+    /// });
+    /// ```
+    pub fn with_style_vars<F: FnOnce()>(&self, style_vars: &[StyleVar], f: F) {
+        for &style_var in style_vars {
+            self.push_style_var(style_var);
+        }
+        f();
+        unsafe { imgui_sys::igPopStyleVar(style_vars.len() as i32) };
+    }
+}

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,8 +1,6 @@
 extern crate imgui_sys;
 
 use ImVec2;
-use Ui;
-use imgui_sys::ImGuiStyleVar;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum StyleVar {
@@ -18,69 +16,4 @@ pub enum StyleVar {
     IndentSpacing(f32),
     GrabMinSize(f32),
     ButtonTextAlign(ImVec2),
-}
-
-impl<'ui> Ui<'ui> {
-    fn push_style_var(&self, style_var: StyleVar) {
-        use StyleVar::*;
-        use imgui_sys::{igPushStyleVar, igPushStyleVarVec};
-        match style_var {
-            Alpha(v) => unsafe { igPushStyleVar(ImGuiStyleVar::Alpha, v) },
-            WindowPadding(v) => unsafe { igPushStyleVarVec(ImGuiStyleVar::WindowPadding, v) },
-            WindowRounding(v) => unsafe { igPushStyleVar(ImGuiStyleVar::WindowRounding, v) },
-            WindowMinSize(v) => unsafe { igPushStyleVarVec(ImGuiStyleVar::WindowMinSize, v) },
-            ChildWindowRounding(v) => unsafe { igPushStyleVar(ImGuiStyleVar::ChildWindowRounding, v) },
-            FramePadding(v) => unsafe { igPushStyleVarVec(ImGuiStyleVar::FramePadding, v) },
-            FrameRounding(v) => unsafe { igPushStyleVar(ImGuiStyleVar::FrameRounding, v) },
-            ItemSpacing(v) => unsafe { igPushStyleVarVec(ImGuiStyleVar::ItemSpacing, v) },
-            ItemInnerSpacing(v) => unsafe { igPushStyleVarVec(ImGuiStyleVar::ItemInnerSpacing, v) },
-            IndentSpacing(v) => unsafe { igPushStyleVar(ImGuiStyleVar::IndentSpacing, v) },
-            GrabMinSize(v) => unsafe { igPushStyleVar(ImGuiStyleVar::GrabMinSize, v) },
-            ButtonTextAlign(v) => unsafe { igPushStyleVarVec(ImGuiStyleVar::ButtonTextAlign, v) }
-        }
-    }
-
-    /// Runs a function after temporarily pushing a value to the style stack.
-    ///
-    /// # Example
-    /// ```rust,no_run
-    /// # use imgui::*;
-    /// # let mut imgui = ImGui::init();
-    /// # let ui = imgui.frame((0, 0), (0, 0), 0.1);
-    /// ui.with_style_var(StyleVar::Alpha(0.2), || {
-    ///     ui.text(im_str!("AB"));
-    /// });
-    /// ui.with_style_var(StyleVar::Alpha(0.4), || {
-    ///     ui.text(im_str!("CD"));
-    /// });
-    /// ```
-    pub fn with_style_var<F: FnOnce()>(&self, style_var: StyleVar, f: F) {
-        self.push_style_var(style_var);
-        f();
-        unsafe { imgui_sys::igPopStyleVar(1) }
-    }
-
-    /// Runs a function after temporarily pushing an array of values into the stack. Supporting
-    /// multiple is also easy since you can freely mix and match them in a safe manner.
-    ///
-    /// # Example
-    /// ```rust,no_run
-    /// # use imgui::*;
-    /// # let mut imgui = ImGui::init();
-    /// # let ui = imgui.frame((0, 0), (0, 0), 0.1);
-    /// # let styles = [StyleVar::Alpha(0.2), StyleVar::WindowPadding(ImVec2::new(1.0, 1.0))];
-    /// ui.with_style_vars(&styles, || {
-    ///     ui.text(im_str!("A"));
-    ///     ui.text(im_str!("B"));
-    ///     ui.text(im_str!("C"));
-    ///     ui.text(im_str!("D"));
-    /// });
-    /// ```
-    pub fn with_style_vars<F: FnOnce()>(&self, style_vars: &[StyleVar], f: F) {
-        for &style_var in style_vars {
-            self.push_style_var(style_var);
-        }
-        f();
-        unsafe { imgui_sys::igPopStyleVar(style_vars.len() as i32) };
-    }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -158,7 +158,6 @@ impl<'ui, 'p> Window<'ui, 'p> {
             .set(ImGuiWindowFlags_AlwaysUseWindowPadding, value);
         self
     }
-
     pub fn build<F: FnOnce()>(self, f: F) {
         let render = unsafe {
             if !self.pos_cond.is_empty() {

--- a/src/window.rs
+++ b/src/window.rs
@@ -158,6 +158,7 @@ impl<'ui, 'p> Window<'ui, 'p> {
             .set(ImGuiWindowFlags_AlwaysUseWindowPadding, value);
         self
     }
+
     pub fn build<F: FnOnce()>(self, f: F) {
         let render = unsafe {
             if !self.pos_cond.is_empty() {

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,6 +1,7 @@
 use imgui_sys;
 use std::marker::PhantomData;
 use std::ptr;
+use ChildFrame;
 
 use super::{ImGuiSetCond, ImGuiWindowFlags, ImGuiWindowFlags_AlwaysAutoResize,
             ImGuiWindowFlags_AlwaysHorizontalScrollbar, ImGuiWindowFlags_AlwaysUseWindowPadding,
@@ -176,6 +177,36 @@ impl<'ui, 'p> Window<'ui, 'p> {
         };
         if render {
             f();
+        }
+        unsafe { imgui_sys::igEnd() };
+    }
+    pub fn build_with_child_frame<CF: FnOnce(), WF: FnOnce()>(self, child_frame: ChildFrame, cf: CF, wf: WF) {
+        let render = unsafe {
+            if !self.pos_cond.is_empty() {
+                imgui_sys::igSetNextWindowPos(self.pos.into(), self.pos_cond);
+            }
+            if !self.size_cond.is_empty() {
+                imgui_sys::igSetNextWindowSize(self.size.into(), self.size_cond);
+            }
+            imgui_sys::igBegin2(
+                self.name.as_ptr(),
+                self.opened.map(|x| x as *mut bool).unwrap_or(
+                    ptr::null_mut(),
+                ),
+                ImVec2::new(0.0, 0.0),
+                self.bg_alpha,
+                self.flags,
+            )
+        };
+
+        let show_border = child_frame.flags.contains(ImGuiWindowFlags_ShowBorders);
+        unsafe { imgui_sys::igBeginChild(self.name.as_ptr(), child_frame.size, show_border, child_frame.flags); }
+        if render {
+            cf();
+        }
+        unsafe { imgui_sys::igEndChild() };
+        if render {
+            wf();
         }
         unsafe { imgui_sys::igEnd() };
     }


### PR DESCRIPTION
 Hello!  I needed to expose more functionality from imgui. Here's my initial idea for supporting child frame's within a window.

    Imgui allows the user to create child frame's, and render into them.
    This isn't exposed currently, this is my first idea at how rust can
    support child frame's.

    Presently it's not the easiest to use, to have a window with a child
    frame supported, internally the imgui library must have called
    beginWindow() for the parent window, before beginChild() is ever called
    for the child frame. Doing this without causing unneeded
    allocations/complexity, and making the API ergonomic is something I hope
    to work on next / get some feedback on.

Functionally, I believe this code to be correct. I have an example of how client code looks using this, and how it renders on my machine here:
![imgui_child_window](https://user-images.githubusercontent.com/1087837/27890881-9a7913d4-61aa-11e7-956c-f1fc64b1f751.png)

I'm pretty unhappy that I ended up with a second self-consuming build() method on the window builder. The fact that I need to pass in two closure's forced me to do this for now, at least until I figure out how to store a closure without a dynamic allocation.

Things I'd like to make better / get some help with:

1. Allow the user to pass in a closure to a member function of the window builder, instead of an additional parameter to the build_with_child_frame() method, add another method to the Window type, that takes the user's function and store's it (so it can be called during build()).
    *  I did some work on this, I added a new field to the Window struct which had the type Option<fn() -> ()>, but the compiler wouldn't let me pass in a closure and store it as a plain function pointer. Do you have any ideas on how we might store a function pointer / closure without an additional allocation? I would think an additional data member on the Window struct would be fine, as long as it is not dynamically allocated.

2. Consolidate back to a single build() method taking a single closure, like the original design, still supporting child frame's though. Right now it's awkward to pass in both closure's like this, the original design made more sense. I get this for free by completing #1 above. If the user can pass in a closure for constructing the child frame, there's no need for the second build_with_child_frame() method.

3. Support arbitrarily nested child-frames. Imgui supports nesting arbitrary frame's, right now this design only supports a maximum of one child frame.