### PR TITLE
expose a method to set font_global_scale

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,10 @@ impl ImGui {
         let io = self.io_mut();
         io.ini_saving_rate = value;
     }
+    pub fn set_font_global_scale(&mut self, value: f32) {
+        let io = self.io_mut();
+        io.font_global_scale = value;
+    }
     pub fn set_mouse_double_click_time(&mut self, value: f32) {
         let io = self.io_mut();
         io.mouse_double_click_time = value;


### PR DESCRIPTION
I noted that you hoped PRs would come with a `cargo fmt` included, but I saw there was _a lot_ of reformatting done by this, so I thought I'd offer to do this as a follow-up rev if required.