### PR TITLE
Work in progress - update to latest gfx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 target
 Cargo.lock
 imgui.ini
+.idea

--- a/imgui-examples/Cargo.toml
+++ b/imgui-examples/Cargo.toml
@@ -9,11 +9,20 @@ license = "MIT/Apache-2.0"
 publish = false
 
 [dev-dependencies]
-gfx = "0.16"
-gfx_window_glutin = "0.17"
+gfx = { git = "https://github.com/gfx-rs/gfx.git" }
+gfx_window_glutin = { git = "https://github.com/gfx-rs/gfx.git" }
 glium = { version = "0.17", default-features = true }
 glutin = "0.9"
 imgui = { version = "0.0.16-pre", path = "../" }
 imgui-gfx-renderer = { version = "0.0.16-pre", path = "../imgui-gfx-renderer" }
 imgui-glium-renderer = { version = "0.0.16-pre", path = "../imgui-glium-renderer" }
 imgui-sys = { version = "0.0.16-pre", path = "../imgui-sys", features = ["gfx", "glium"] }
+
+[[example]]
+name = "hello_world"
+
+[[example]]
+name = "hello_gfx"
+
+[[example]]
+name = "test_window"

--- a/imgui-gfx-renderer/Cargo.toml
+++ b/imgui-gfx-renderer/Cargo.toml
@@ -12,6 +12,6 @@ categories = ["gui", "rendering"]
 travis-ci = { repository = "Gekkio/imgui-rs" }
 
 [dependencies]
-gfx = "0.16"
+gfx = { git = "https://github.com/gfx-rs/gfx.git" }
 imgui = { version = "0.0.16-pre", path = "../" }
 imgui-sys = { version = "0.0.16-pre", path = "../imgui-sys", features = ["gfx"] }

--- a/imgui-sys/Cargo.toml
+++ b/imgui-sys/Cargo.toml
@@ -15,7 +15,7 @@ travis-ci = { repository = "Gekkio/imgui-rs" }
 [dependencies]
 bitflags = "0.9"
 glium = { version = "0.17", default-features = false, optional = true }
-gfx = { version = "0.16", optional = true }
+gfx = { git = "https://github.com/gfx-rs/gfx.git", optional = true }
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
This is a work in progress branch bringing compatibility with the bleeding edge changes in gfx, using their examples as a reference.

It isn't intended to be considered for merge yet, but might be useful for the next major release of gfx.

The gfx example can be run from the imgui-examples directory with this command:

```
cargo run --example hello_gfx
```