### PR TITLE
Blurry fonts on glium renderer

### DIFF
--- a/imgui-glium-renderer/src/lib.rs
+++ b/imgui-glium-renderer/src/lib.rs
@@ -84,7 +84,7 @@ impl Renderer {
                                         draw_list: DrawList<'a>)
                                         -> RendererResult<()> {
         use glium::{Blend, DrawParameters, Rect};
-        use glium::uniforms::MagnifySamplerFilter;
+        use glium::uniforms::{MinifySamplerFilter, MagnifySamplerFilter};
 
         try!(self.device_objects.upload_vertex_buffer(&self.ctx, draw_list.vtx_buffer));
         try!(self.device_objects.upload_index_buffer(&self.ctx, draw_list.idx_buffer));
@@ -118,7 +118,8 @@ impl Renderer {
                               &uniform! {
                           matrix: matrix,
                           tex: self.device_objects.texture.sampled()
-                              .magnify_filter(MagnifySamplerFilter::Nearest),
+                              .magnify_filter(MagnifySamplerFilter::Nearest)
+                              .minify_filter(MinifySamplerFilter::Nearest),
                       },
                               &DrawParameters {
                                   blend: Blend::alpha_blending(),


### PR DESCRIPTION
Hey, thanks for making this library.
I tried loading a custom TTF font using imgui-sys, but the imgui-glium-renderer then renders blurry text, like this:
![screenshot_2017-10-23_22-01-02](https://user-images.githubusercontent.com/1564672/31910819-fce480ea-b83e-11e7-8454-94bcb7bdd735.png)

The cause seems to be that glium sets `minify_filter` to `MinifySamplerFilter::LinearMipmapLinear` by default. Text renders correctly if this property is set to `Linear` or `Nearest` instead (imgui's bundled examples use `Linear`).

The text seems to render fine on the gfx renderer.