### PR TITLE
make Ui.imgui public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,7 +284,7 @@ pub struct DrawList<'a> {
 }
 
 pub struct Ui<'ui> {
-    imgui: &'ui ImGui,
+    pub imgui: &'ui ImGui,
 }
 
 static FMT: &'static [u8] = b"%s\0";


### PR DESCRIPTION
Hello.
I am attempting to position a widget on screen, and needed the window size.
In order to work it out, i made Ui.imgui public, so I can access the display_size() method.

Not sure this is the right fix?

Based on https://github.com/Gekkio/imgui-rs/blob/master/imgui-examples/examples/hello_gfx.rs

I am doing something like this:

```rust
fn hello_world<'a>(ui: &Ui<'a>) -> bool {
    let (wnd_w, wnd_h) = ui.imgui.display_size();
    let (wdg_w, wdg_h) = (60., 30.);
    const DISTANCE: f32 =  10.0;
    let window_pos = (wnd_w - wdg_w - DISTANCE, wnd_h - wdg_h - DISTANCE);
    ui.window(im_str!(""))
        .position(window_pos, ImGuiCond::Always)
        .title_bar(false)
        .resizable(false)
        .movable(false)
        .save_settings(false)
        .size((wdg_w, wdg_h), ImGuiCond::FirstUseEver)
        .build(|| {
            ui.text(im_str!("hello"));
        });

    true
}
```