### PR TITLE
examples: Fix winit deprecation warnings

### DIFF
--- a/imgui-examples/examples/support/mod.rs
+++ b/imgui-examples/examples/support/mod.rs
@@ -105,8 +105,12 @@ pub fn run<F: FnMut(&Ui) -> bool>(title: String, clear_color: [f32; 4], mut run_
         update_mouse(&mut imgui, &mut mouse_state);
 
         let gl_window = display.gl_window();
-        let size_points = gl_window.get_inner_size_points().unwrap();
-        let size_pixels = gl_window.get_inner_size_pixels().unwrap();
+        let size_pixels = gl_window.get_inner_size().unwrap();
+        let hdipi = gl_window.hidpi_factor();
+        let size_points = (
+            (size_pixels.0 as f32 / hdipi) as u32,
+            (size_pixels.1 as f32 / hdipi) as u32,
+        );
 
         let ui = imgui.frame(size_points, size_pixels, delta_s);
         if !run_ui(&ui) {

--- a/imgui-examples/examples/support_gfx/mod.rs
+++ b/imgui-examples/examples/support_gfx/mod.rs
@@ -131,8 +131,12 @@ pub fn run<F: FnMut(&Ui) -> bool>(title: String, clear_color: [f32; 4], mut run_
 
         update_mouse(&mut imgui, &mut mouse_state);
 
-        let size_points = window.get_inner_size_points().unwrap();
-        let size_pixels = window.get_inner_size_pixels().unwrap();
+        let size_pixels = window.get_inner_size().unwrap();
+        let hdipi = window.hidpi_factor();
+        let size_points = (
+            (size_pixels.0 as f32 / hdipi) as u32,
+            (size_pixels.1 as f32 / hdipi) as u32,
+        );
 
         let ui = imgui.frame(size_points, size_pixels, delta_s);
         if !run_ui(&ui) {


### PR DESCRIPTION
Since the following pull request
https://github.com/tomaka/winit/pull/319, `winit` has deprecated
`get_inner_size_points()` and `get_inner_size_pixels()`.

This commit replaces the deprecated API by `get_inner_size()` and
`hidpi_factor()`. The size in points in computed from the returned
`hidpi_factor`.