### PR TITLE
Allow mouse cursor to be updated

### DIFF
--- a/imgui-examples/examples/support/mod.rs
+++ b/imgui-examples/examples/support/mod.rs
@@ -1,4 +1,4 @@
-use imgui::{ImGui, Ui};
+use imgui::{ImGui, ImGuiMouseCursor, Ui};
 use std::time::Instant;
 
 #[derive(Copy, Clone, PartialEq, Debug, Default)]
@@ -105,6 +105,26 @@ pub fn run<F: FnMut(&Ui) -> bool>(title: String, clear_color: [f32; 4], mut run_
         update_mouse(&mut imgui, &mut mouse_state);
 
         let gl_window = display.gl_window();
+
+        let mouse_cursor = imgui.mouse_cursor();
+        if imgui.mouse_draw_cursor() || mouse_cursor == ImGuiMouseCursor::None {
+            // Hide OS cursor
+            gl_window.set_cursor_state(glutin::CursorState::Hide).unwrap();
+        } else {
+            // Set OS cursor
+            gl_window.set_cursor_state(glutin::CursorState::Normal).unwrap();
+            gl_window.set_cursor(match mouse_cursor {
+                ImGuiMouseCursor::None => unreachable!("mouse_cursor was None!"),
+                ImGuiMouseCursor::Arrow => glutin::MouseCursor::Arrow,
+                ImGuiMouseCursor::TextInput => glutin::MouseCursor::Text,
+                ImGuiMouseCursor::Move => glutin::MouseCursor::Move,
+                ImGuiMouseCursor::ResizeNS => glutin::MouseCursor::NsResize,
+                ImGuiMouseCursor::ResizeEW => glutin::MouseCursor::EwResize,
+                ImGuiMouseCursor::ResizeNESW => glutin::MouseCursor::NeswResize,
+                ImGuiMouseCursor::ResizeNWSE => glutin::MouseCursor::NwseResize,
+            });
+        }
+
         let size_pixels = gl_window.get_inner_size().unwrap();
         let hdipi = gl_window.hidpi_factor();
         let size_points = (

--- a/imgui-examples/examples/support_gfx/mod.rs
+++ b/imgui-examples/examples/support_gfx/mod.rs
@@ -1,4 +1,4 @@
-use imgui::{ImGui, Ui};
+use imgui::{ImGui, ImGuiMouseCursor, Ui};
 use imgui_gfx_renderer::{Renderer, Shaders};
 use std::time::Instant;
 
@@ -130,6 +130,25 @@ pub fn run<F: FnMut(&Ui) -> bool>(title: String, clear_color: [f32; 4], mut run_
         last_frame = now;
 
         update_mouse(&mut imgui, &mut mouse_state);
+
+        let mouse_cursor = imgui.mouse_cursor();
+        if imgui.mouse_draw_cursor() || mouse_cursor == ImGuiMouseCursor::None {
+            // Hide OS cursor
+            window.set_cursor_state(glutin::CursorState::Hide).unwrap();
+        } else {
+            // Set OS cursor
+            window.set_cursor_state(glutin::CursorState::Normal).unwrap();
+            window.set_cursor(match mouse_cursor {
+                ImGuiMouseCursor::None => unreachable!("mouse_cursor was None!"),
+                ImGuiMouseCursor::Arrow => glutin::MouseCursor::Arrow,
+                ImGuiMouseCursor::TextInput => glutin::MouseCursor::Text,
+                ImGuiMouseCursor::Move => glutin::MouseCursor::Move,
+                ImGuiMouseCursor::ResizeNS => glutin::MouseCursor::NsResize,
+                ImGuiMouseCursor::ResizeEW => glutin::MouseCursor::EwResize,
+                ImGuiMouseCursor::ResizeNESW => glutin::MouseCursor::NeswResize,
+                ImGuiMouseCursor::ResizeNWSE => glutin::MouseCursor::NwseResize,
+            });
+        }
 
         let size_pixels = window.get_inner_size().unwrap();
         let hdipi = window.hidpi_factor();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,8 @@ use std::str;
 use sys::ImGuiStyleVar;
 
 pub use sys::{ImDrawIdx, ImDrawVert, ImGuiColorEditFlags, ImGuiHoveredFlags, ImGuiInputTextFlags,
-              ImGuiKey, ImGuiSelectableFlags, ImGuiCond, ImGuiCol, ImGuiStyle, ImGuiTreeNodeFlags,
-              ImGuiWindowFlags, ImVec2, ImVec4};
+              ImGuiKey, ImGuiMouseCursor, ImGuiSelectableFlags, ImGuiCond, ImGuiCol, ImGuiStyle,
+              ImGuiTreeNodeFlags, ImGuiWindowFlags, ImVec2, ImVec4};
 pub use child_frame::ChildFrame;
 pub use color_editors::{ColorButton, ColorEdit, ColorEditMode, ColorFormat, ColorPicker,
                         ColorPickerMode, ColorPreview, EditableColor};
@@ -198,9 +198,30 @@ impl ImGui {
         let io = self.io_mut();
         io.mouse_wheel = value;
     }
+    /// Set to `true` to have ImGui draw the cursor in software.
+    /// If `false`, the OS cursor is used (default to `false`).
     pub fn set_mouse_draw_cursor(&mut self, value: bool) {
         let io = self.io_mut();
         io.mouse_draw_cursor = value;
+    }
+    pub fn mouse_draw_cursor(&self) -> bool {
+        let io = self.io();
+        io.mouse_draw_cursor
+    }
+    /// Set currently displayed cursor.
+    /// Requires support in the windowing back-end if OS cursor is used.
+    /// OS cursor is used if `mouse_draw_cursor` is set to `false` with
+    /// [set_mouse_draw_cursor](#method.set_mouse_draw_cursor).
+    pub fn set_mouse_cursor(&self, cursor: ImGuiMouseCursor) {
+        unsafe {
+            sys::igSetMouseCursor(cursor);
+        }
+    }
+    /// Get currently displayed cursor.
+    pub fn mouse_cursor(&self) -> ImGuiMouseCursor {
+        unsafe {
+            sys::igGetMouseCursor()
+        }
     }
     pub fn key_ctrl(&self) -> bool {
         let io = self.io();


### PR DESCRIPTION
This PR updates the mouse cursor in the examples.
The necessary helper functions are added into the lib.

Here is the result after the merge request. This is an example when a window is resized:
![Cursor is update while resizing a window](https://user-images.githubusercontent.com/14120117/37887799-c1cdaf48-30fe-11e8-99d2-cf50e1b3b696.png)

Prior to this PR, the mouse cursor would have been the default Arrow.