### PR TITLE
Add some helper functions: mouse_delta, get_window_size, is_item_active

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -392,6 +392,18 @@ impl<'ui> Ui<'ui> {
         }
         (out.x, out.y)
     }
+    /// Get current window's width in pixels
+    pub fn get_window_width(&self) -> f32 {
+        unsafe {
+            sys::igGetWindowWidth()
+        }
+    }
+    /// Get current window's height in pixels
+    pub fn get_window_height(&self) -> f32 {
+        unsafe {
+            sys::igGetWindowHeight()
+        }
+    }
 }
 
 // Layout

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,6 +190,11 @@ impl ImGui {
         io.mouse_pos.x = x;
         io.mouse_pos.y = y;
     }
+    /// Get mouse's position's delta between the current and the last frame.
+    pub fn mouse_delta(&self) -> (f32, f32) {
+        let io = self.io();
+        (io.mouse_delta.x, io.mouse_delta.y)
+    }
     pub fn set_mouse_down(&mut self, states: &[bool; 5]) {
         let io = self.io_mut();
         io.mouse_down = *states;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -384,6 +384,14 @@ impl<'a> Ui<'a> {
 // Window
 impl<'ui> Ui<'ui> {
     pub fn window<'p>(&self, name: &'p ImStr) -> Window<'ui, 'p> { Window::new(self, name) }
+    /// Get current window's size in pixels
+    pub fn get_window_size(&self) -> (f32, f32) {
+        let mut out = ImVec2::new(0.0, 0.0);
+        unsafe {
+            sys::igGetWindowSize(&mut out as *mut ImVec2);
+        }
+        (out.x, out.y)
+    }
 }
 
 // Layout

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1088,6 +1088,24 @@ impl<'ui> Ui<'ui> {
     }
 }
 
+impl<'ui> Ui<'ui> {
+    /// Runs a function after temporarily pushing an array of values to the
+    /// style and color stack.
+    pub fn with_style_and_color_vars<F, C>(
+        &self,
+        style_vars: &[StyleVar],
+        color_vars: &[(ImGuiCol, C)],
+        f: F,
+    ) where
+        F: FnOnce(),
+        C: Into<ImVec4> + Copy,
+    {
+        self.with_style_vars(style_vars, || {
+            self.with_color_vars(color_vars, f);
+        });
+    }
+}
+
 /// # Utilities
 impl<'ui> Ui<'ui> {
     /// Returns `true` if the last item is being hovered by the mouse.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1166,4 +1166,13 @@ impl<'ui> Ui<'ui> {
             sys::igIsItemActive()
         }
     }
+
+    /// Group items together as a single item.
+    ///
+    /// May be useful to handle the same mouse event on a group of items, for example.
+    pub fn group<F: FnOnce()>(&self, f: F) {
+        unsafe { sys::igBeginGroup(); }
+        f();
+        unsafe { sys::igEndGroup(); }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -954,6 +954,19 @@ impl<'ui> Ui<'ui> {
 }
 
 impl<'ui> Ui<'ui> {
+    /// Get height of a line of previously drawn text item
+    pub fn get_text_line_height_with_spacing(&self) -> f32 {
+        unsafe { sys::igGetTextLineHeightWithSpacing() }
+    }
+    /// Get previously drawn item's size
+    pub fn get_item_rect_size(&self) -> (f32, f32) {
+        let mut out = ImVec2::new(0.0, 0.0);
+        unsafe { sys::igGetItemRectSize(&mut out); }
+        (out.x, out.y)
+    }
+}
+
+impl<'ui> Ui<'ui> {
     /// Creates a progress bar. Fraction is the progress level with 0.0 = 0% and 1.0 = 100%.
     ///
     /// # Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -444,6 +444,40 @@ impl<'ui> Ui<'ui> {
     }
 
     pub fn get_columns_count(&self) -> i32 { unsafe { sys::igGetColumnsCount() } }
+
+    /// Get cursor position on the screen, in screen coordinates.
+    /// This sets the point on which the next widget will be drawn.
+    ///
+    /// This is especially useful for drawing, as the drawing API uses
+    /// screen coordiantes.
+    pub fn get_cursor_screen_pos(&self) -> (f32, f32) {
+        let mut out = ImVec2::new(0.0, 0.0);
+        unsafe {
+            sys::igGetCursorScreenPos(&mut out);
+        }
+        (out.x, out.y)
+    }
+
+    /// Set cursor position on the screen, in screen coordinates.
+    /// This sets the point on which the next widget will be drawn.
+    pub fn set_cursor_screen_pos<P: Into<ImVec2>>(&self, pos: P) {
+        unsafe { sys::igSetCursorScreenPos(pos.into()) }
+    }
+
+    /// Get cursor position on the screen, in window coordinates.
+    pub fn get_cursor_pos(&self) -> (f32, f32) {
+        let mut out = ImVec2::new(0.0, 0.0);
+        unsafe {
+            sys::igGetCursorPos(&mut out);
+        }
+        (out.x, out.y)
+    }
+
+    /// Set cursor position on the screen, in window coordinates.
+    /// This sets the point on which the next widget will be drawn.
+    pub fn set_cursor_pos<P: Into<ImVec2>>(&self, pos: P) {
+        unsafe { sys::igSetCursorPos(pos.into()) }
+    }
 }
 
 // ID scopes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1099,4 +1099,11 @@ impl<'ui> Ui<'ui> {
     pub fn is_item_hovered(&self) -> bool {
         unsafe { sys::igIsItemHovered(ImGuiHoveredFlags::empty()) }
     }
+
+    /// Returns `true` if the last item is being active.
+    pub fn is_item_active(&self) -> bool {
+        unsafe {
+            sys::igIsItemActive()
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -392,18 +392,6 @@ impl<'ui> Ui<'ui> {
         }
         (out.x, out.y)
     }
-    /// Get current window's width in pixels
-    pub fn get_window_width(&self) -> f32 {
-        unsafe {
-            sys::igGetWindowWidth()
-        }
-    }
-    /// Get current window's height in pixels
-    pub fn get_window_height(&self) -> f32 {
-        unsafe {
-            sys::igGetWindowHeight()
-        }
-    }
 }
 
 // Layout


### PR DESCRIPTION
Include 3 helper functions to `imgui` crate:

- `mouse_delta`: Get mouse delta since previous frame
- `get_window_size`: Wraps `sys::igGetWindowSize` to get latest window's size.
- `is_item_active`: Wraps `sys:igIsItemActive`

I would just like to know your opinion regarding the naming of the functions. I tried to use the same convention as the code around each function.