### PR TITLE
Wraps the dear ImGui custom drawing API

### DIFF
--- a/imgui-examples/examples/test_drawing_channels_split.rs
+++ b/imgui-examples/examples/test_drawing_channels_split.rs
@@ -9,8 +9,11 @@ const WHITE: [f32; 4] = [1.0, 1.0, 1.0, 1.0];
 const RED: [f32; 4] = [1.0, 0.0, 0.0, 1.0];
 
 fn main() {
-    support::run("test_drawing_channels_split".to_owned(), CLEAR_COLOR, |ui| {
-        ui.with_window_draw_list(|draw_list| {
+    support::run(
+        "test_drawing_channels_split".to_owned(),
+        CLEAR_COLOR,
+        |ui| {
+            let draw_list = ui.get_window_draw_list();
             // Will draw channel 0 first, then channel 1, whatever the order of
             // the calls in the code.
             //
@@ -38,7 +41,7 @@ fn main() {
                     .num_segments(50)
                     .build();
             });
-        });
-        true
-    });
+            true
+        },
+    );
 }

--- a/imgui-examples/examples/test_drawing_channels_split.rs
+++ b/imgui-examples/examples/test_drawing_channels_split.rs
@@ -1,0 +1,44 @@
+extern crate glium;
+extern crate imgui;
+extern crate imgui_glium_renderer;
+
+mod support;
+
+const CLEAR_COLOR: [f32; 4] = [0.2, 0.2, 0.2, 1.0];
+const WHITE: [f32; 4] = [1.0, 1.0, 1.0, 1.0];
+const RED: [f32; 4] = [1.0, 0.0, 0.0, 1.0];
+
+fn main() {
+    support::run("test_drawing_channels_split".to_owned(), CLEAR_COLOR, |ui| {
+        ui.with_window_draw_list(|draw_list| {
+            // Will draw channel 0 first, then channel 1, whatever the order of
+            // the calls in the code.
+            //
+            // Here, we draw a red line on channel 1 then a white circle on
+            // channel 0. As a result, the red line will always appear on top of
+            // the white circle.
+            draw_list.channels_split(2, |draw_list| {
+                const RADIUS: f32 = 100.0;
+                let canvas_pos = ui.get_cursor_screen_pos();
+                draw_list.channels_set_current(1);
+                draw_list
+                    .add_line(
+                        canvas_pos,
+                        [canvas_pos.0 + RADIUS, canvas_pos.1 + RADIUS],
+                        RED,
+                    )
+                    .thickness(5.0)
+                    .build();
+
+                draw_list.channels_set_current(0);
+                let center = (canvas_pos.0 + RADIUS, canvas_pos.1 + RADIUS);
+                draw_list
+                    .add_circle(center, RADIUS, WHITE)
+                    .thickness(10.0)
+                    .num_segments(50)
+                    .build();
+            });
+        });
+        true
+    });
+}

--- a/imgui-examples/examples/test_drawing_channels_split.rs
+++ b/imgui-examples/examples/test_drawing_channels_split.rs
@@ -20,10 +20,10 @@ fn main() {
             // Here, we draw a red line on channel 1 then a white circle on
             // channel 0. As a result, the red line will always appear on top of
             // the white circle.
-            draw_list.channels_split(2, |draw_list| {
+            draw_list.channels_split(2, |channels| {
                 const RADIUS: f32 = 100.0;
                 let canvas_pos = ui.get_cursor_screen_pos();
-                draw_list.channels_set_current(1);
+                channels.set_current(1);
                 draw_list
                     .add_line(
                         canvas_pos,
@@ -33,7 +33,7 @@ fn main() {
                     .thickness(5.0)
                     .build();
 
-                draw_list.channels_set_current(0);
+                channels.set_current(0);
                 let center = (canvas_pos.0 + RADIUS, canvas_pos.1 + RADIUS);
                 draw_list
                     .add_circle(center, RADIUS, WHITE)

--- a/imgui-examples/examples/test_window_impl.rs
+++ b/imgui-examples/examples/test_window_impl.rs
@@ -779,106 +779,37 @@ fn show_example_app_custom_rendering(ui: &Ui, state: &mut CustomRenderingState, 
             ui.text("Primitives");
             // TODO: Add DragFloat to change value of sz
             ui.color_edit(im_str!("Color"), &mut state.col).build();
+            let draw_list = ui.get_window_draw_list();
             let p = ui.get_cursor_screen_pos();
             let spacing = 8.0;
             let mut y = p.1 + 4.0;
             for n in 0..2 {
                 let mut x = p.0 + 4.0;
                 let thickness = if n == 0 { 1.0 } else { 4.0 };
-                ui.with_window_draw_list(|draw_list| {
-                    draw_list
-                        .add_circle(
-                            (x + state.sz * 0.5, y + state.sz * 0.5),
-                            state.sz * 0.5,
-                            state.col,
-                        )
-                        .num_segments(20)
-                        .thickness(thickness)
-                        .build();
-                    x += state.sz + spacing;
-                    draw_list
-                        .add_rect((x, y), (x + state.sz, y + state.sz), state.col)
-                        .thickness(thickness)
-                        .build();
-                    x += state.sz + spacing;
-                    draw_list
-                        .add_rect((x, y), (x + state.sz, y + state.sz), state.col)
-                        .thickness(thickness)
-                        .rounding(10.0)
-                        .build();
-                    x += state.sz + spacing;
-                    draw_list
-                        .add_rect((x, y), (x + state.sz, y + state.sz), state.col)
-                        .thickness(thickness)
-                        .rounding(10.0)
-                        .round_top_right(false)
-                        .round_bot_left(false)
-                        .build();
-                    x += state.sz + spacing;
-                    draw_list
-                        .add_triangle(
-                            (x + state.sz * 0.5, y),
-                            (x + state.sz, y + state.sz - 0.5),
-                            (x, y + state.sz - 0.5),
-                            state.col,
-                        )
-                        .thickness(thickness)
-                        .build();
-                    x += state.sz + spacing;
-                    draw_list
-                        .add_line((x, y), (x + state.sz, y), state.col)
-                        .thickness(thickness)
-                        .build();
-                    x += state.sz + spacing;
-                    draw_list
-                        .add_line((x, y), (x + state.sz, y + state.sz), state.col)
-                        .thickness(thickness)
-                        .build();
-                    x += state.sz + spacing;
-                    draw_list
-                        .add_line((x, y), (x, y + state.sz), state.col)
-                        .thickness(thickness)
-                        .build();
-                    x += spacing;
-                    draw_list
-                        .add_bezier_curve(
-                            (x, y),
-                            (x + state.sz * 1.3, y + state.sz * 0.3),
-                            (x + state.sz - state.sz * 1.3, y + state.sz - state.sz * 0.3),
-                            (x + state.sz, y + state.sz),
-                            state.col,
-                        )
-                        .thickness(thickness)
-                        .build();
-                });
-                y += state.sz + spacing;
-            }
-            ui.with_window_draw_list(|draw_list| {
-                let mut x = p.0 + 4.0;
                 draw_list
                     .add_circle(
                         (x + state.sz * 0.5, y + state.sz * 0.5),
                         state.sz * 0.5,
                         state.col,
                     )
-                    .num_segments(32)
-                    .filled(true)
+                    .num_segments(20)
+                    .thickness(thickness)
                     .build();
                 x += state.sz + spacing;
                 draw_list
                     .add_rect((x, y), (x + state.sz, y + state.sz), state.col)
-                    .filled(true)
+                    .thickness(thickness)
                     .build();
                 x += state.sz + spacing;
                 draw_list
                     .add_rect((x, y), (x + state.sz, y + state.sz), state.col)
-                    .filled(true)
+                    .thickness(thickness)
                     .rounding(10.0)
                     .build();
                 x += state.sz + spacing;
                 draw_list
                     .add_rect((x, y), (x + state.sz, y + state.sz), state.col)
-                    .filled(true)
+                    .thickness(thickness)
                     .rounding(10.0)
                     .round_top_right(false)
                     .round_bot_left(false)
@@ -891,22 +822,88 @@ fn show_example_app_custom_rendering(ui: &Ui, state: &mut CustomRenderingState, 
                         (x, y + state.sz - 0.5),
                         state.col,
                     )
-                    .filled(true)
+                    .thickness(thickness)
                     .build();
                 x += state.sz + spacing;
-                const MULTICOLOR_RECT_CORNER_COLOR1: [f32; 3] = [0.0, 0.0, 0.0];
-                const MULTICOLOR_RECT_CORNER_COLOR2: [f32; 3] = [1.0, 0.0, 0.0];
-                const MULTICOLOR_RECT_CORNER_COLOR3: [f32; 3] = [1.0, 1.0, 0.0];
-                const MULTICOLOR_RECT_CORNER_COLOR4: [f32; 3] = [0.0, 1.0, 0.0];
-                draw_list.add_rect_filled_multicolor(
-                    (x, y),
-                    (x + state.sz, y + state.sz),
-                    MULTICOLOR_RECT_CORNER_COLOR1,
-                    MULTICOLOR_RECT_CORNER_COLOR2,
-                    MULTICOLOR_RECT_CORNER_COLOR3,
-                    MULTICOLOR_RECT_CORNER_COLOR4,
-                );
-            });
+                draw_list
+                    .add_line((x, y), (x + state.sz, y), state.col)
+                    .thickness(thickness)
+                    .build();
+                x += state.sz + spacing;
+                draw_list
+                    .add_line((x, y), (x + state.sz, y + state.sz), state.col)
+                    .thickness(thickness)
+                    .build();
+                x += state.sz + spacing;
+                draw_list
+                    .add_line((x, y), (x, y + state.sz), state.col)
+                    .thickness(thickness)
+                    .build();
+                x += spacing;
+                draw_list
+                    .add_bezier_curve(
+                        (x, y),
+                        (x + state.sz * 1.3, y + state.sz * 0.3),
+                        (x + state.sz - state.sz * 1.3, y + state.sz - state.sz * 0.3),
+                        (x + state.sz, y + state.sz),
+                        state.col,
+                    )
+                    .thickness(thickness)
+                    .build();
+                y += state.sz + spacing;
+            }
+            let mut x = p.0 + 4.0;
+            draw_list
+                .add_circle(
+                    (x + state.sz * 0.5, y + state.sz * 0.5),
+                    state.sz * 0.5,
+                    state.col,
+                )
+                .num_segments(32)
+                .filled(true)
+                .build();
+            x += state.sz + spacing;
+            draw_list
+                .add_rect((x, y), (x + state.sz, y + state.sz), state.col)
+                .filled(true)
+                .build();
+            x += state.sz + spacing;
+            draw_list
+                .add_rect((x, y), (x + state.sz, y + state.sz), state.col)
+                .filled(true)
+                .rounding(10.0)
+                .build();
+            x += state.sz + spacing;
+            draw_list
+                .add_rect((x, y), (x + state.sz, y + state.sz), state.col)
+                .filled(true)
+                .rounding(10.0)
+                .round_top_right(false)
+                .round_bot_left(false)
+                .build();
+            x += state.sz + spacing;
+            draw_list
+                .add_triangle(
+                    (x + state.sz * 0.5, y),
+                    (x + state.sz, y + state.sz - 0.5),
+                    (x, y + state.sz - 0.5),
+                    state.col,
+                )
+                .filled(true)
+                .build();
+            x += state.sz + spacing;
+            const MULTICOLOR_RECT_CORNER_COLOR1: [f32; 3] = [0.0, 0.0, 0.0];
+            const MULTICOLOR_RECT_CORNER_COLOR2: [f32; 3] = [1.0, 0.0, 0.0];
+            const MULTICOLOR_RECT_CORNER_COLOR3: [f32; 3] = [1.0, 1.0, 0.0];
+            const MULTICOLOR_RECT_CORNER_COLOR4: [f32; 3] = [0.0, 1.0, 0.0];
+            draw_list.add_rect_filled_multicolor(
+                (x, y),
+                (x + state.sz, y + state.sz),
+                MULTICOLOR_RECT_CORNER_COLOR1,
+                MULTICOLOR_RECT_CORNER_COLOR2,
+                MULTICOLOR_RECT_CORNER_COLOR3,
+                MULTICOLOR_RECT_CORNER_COLOR4,
+            );
             ui.dummy(((state.sz + spacing) * 8.0, (state.sz + spacing) * 3.0));
             ui.separator();
 
@@ -943,77 +940,74 @@ fn show_example_app_custom_rendering(ui: &Ui, state: &mut CustomRenderingState, 
             if canvas_size.1 < 50.0 {
                 canvas_size.1 = 50.0;
             }
-            ui.with_window_draw_list(|draw_list| {
-                const CANVAS_CORNER_COLOR1: [f32; 3] = [0.2, 0.2, 0.2];
-                const CANVAS_CORNER_COLOR2: [f32; 3] = [0.2, 0.2, 0.24];
-                const CANVAS_CORNER_COLOR3: [f32; 3] = [0.24, 0.24, 0.27];
-                const CANVAS_CORNER_COLOR4: [f32; 3] = [0.2, 0.2, 0.24];
-                draw_list.add_rect_filled_multicolor(
+            const CANVAS_CORNER_COLOR1: [f32; 3] = [0.2, 0.2, 0.2];
+            const CANVAS_CORNER_COLOR2: [f32; 3] = [0.2, 0.2, 0.24];
+            const CANVAS_CORNER_COLOR3: [f32; 3] = [0.24, 0.24, 0.27];
+            const CANVAS_CORNER_COLOR4: [f32; 3] = [0.2, 0.2, 0.24];
+            draw_list.add_rect_filled_multicolor(
+                canvas_pos,
+                (canvas_pos.0 + canvas_size.0, canvas_pos.1 + canvas_size.1),
+                CANVAS_CORNER_COLOR1,
+                CANVAS_CORNER_COLOR2,
+                CANVAS_CORNER_COLOR3,
+                CANVAS_CORNER_COLOR4,
+            );
+            const CANVAS_BORDER_COLOR: [f32; 3] = [1.0, 1.0, 1.0];
+            draw_list
+                .add_rect(
                     canvas_pos,
                     (canvas_pos.0 + canvas_size.0, canvas_pos.1 + canvas_size.1),
-                    CANVAS_CORNER_COLOR1,
-                    CANVAS_CORNER_COLOR2,
-                    CANVAS_CORNER_COLOR3,
-                    CANVAS_CORNER_COLOR4,
-                );
-                const CANVAS_BORDER_COLOR: [f32; 3] = [1.0, 1.0, 1.0];
-                draw_list
-                    .add_rect(
-                        canvas_pos,
-                        (canvas_pos.0 + canvas_size.0, canvas_pos.1 + canvas_size.1),
-                        CANVAS_BORDER_COLOR,
-                    )
-                    .build();
+                    CANVAS_BORDER_COLOR,
+                )
+                .build();
 
-                let mut adding_preview = false;
-                ui.invisible_button(im_str!("canvas"), canvas_size);
-                let mouse_pos = ui.imgui().mouse_pos();
-                let mouse_pos_in_canvas = (mouse_pos.0 - canvas_pos.0, mouse_pos.1 - canvas_pos.1);
-                if state.adding_line {
-                    adding_preview = true;
+            let mut adding_preview = false;
+            ui.invisible_button(im_str!("canvas"), canvas_size);
+            let mouse_pos = ui.imgui().mouse_pos();
+            let mouse_pos_in_canvas = (mouse_pos.0 - canvas_pos.0, mouse_pos.1 - canvas_pos.1);
+            if state.adding_line {
+                adding_preview = true;
+                state.points.push(mouse_pos_in_canvas);
+                if !ui.imgui().is_mouse_down(ImMouseButton::Left) {
+                    state.adding_line = false;
+                    adding_preview = false;
+                }
+            }
+            if ui.is_item_hovered() {
+                if !state.adding_line && ui.imgui().is_mouse_clicked(ImMouseButton::Left) {
                     state.points.push(mouse_pos_in_canvas);
-                    if !ui.imgui().is_mouse_down(ImMouseButton::Left) {
-                        state.adding_line = false;
-                        adding_preview = false;
-                    }
+                    state.adding_line = true;
                 }
-                if ui.is_item_hovered() {
-                    if !state.adding_line && ui.imgui().is_mouse_clicked(ImMouseButton::Left) {
-                        state.points.push(mouse_pos_in_canvas);
-                        state.adding_line = true;
-                    }
-                    if ui.imgui().is_mouse_clicked(ImMouseButton::Right) && !state.points.is_empty()
-                    {
-                        state.adding_line = false;
-                        adding_preview = false;
-                        state.points.pop();
-                        state.points.pop();
-                    }
-                }
-                draw_list.with_clip_rect_intersect(
-                    canvas_pos,
-                    (canvas_pos.0 + canvas_size.0, canvas_pos.1 + canvas_size.1),
-                    || {
-                        const LINE_COLOR: [f32; 3] = [1.0, 1.0, 0.0];
-                        for line in state.points.chunks(2) {
-                            if line.len() < 2 {
-                                break;
-                            }
-                            let (p1, p2) = (line[0], line[1]);
-                            draw_list
-                                .add_line(
-                                    (canvas_pos.0 + p1.0, canvas_pos.1 + p1.1),
-                                    (canvas_pos.0 + p2.0, canvas_pos.1 + p2.1),
-                                    LINE_COLOR,
-                                )
-                                .thickness(2.0)
-                                .build();
-                        }
-                    },
-                );
-                if adding_preview {
+                if ui.imgui().is_mouse_clicked(ImMouseButton::Right) && !state.points.is_empty() {
+                    state.adding_line = false;
+                    adding_preview = false;
+                    state.points.pop();
                     state.points.pop();
                 }
-            });
+            }
+            draw_list.with_clip_rect_intersect(
+                canvas_pos,
+                (canvas_pos.0 + canvas_size.0, canvas_pos.1 + canvas_size.1),
+                || {
+                    const LINE_COLOR: [f32; 3] = [1.0, 1.0, 0.0];
+                    for line in state.points.chunks(2) {
+                        if line.len() < 2 {
+                            break;
+                        }
+                        let (p1, p2) = (line[0], line[1]);
+                        draw_list
+                            .add_line(
+                                (canvas_pos.0 + p1.0, canvas_pos.1 + p1.1),
+                                (canvas_pos.0 + p2.0, canvas_pos.1 + p2.1),
+                                LINE_COLOR,
+                            )
+                            .thickness(2.0)
+                            .build();
+                    }
+                },
+            );
+            if adding_preview {
+                state.points.pop();
+            }
         });
 }

--- a/imgui-examples/examples/test_window_impl.rs
+++ b/imgui-examples/examples/test_window_impl.rs
@@ -47,6 +47,7 @@ struct State {
     file_menu: FileMenuState,
     radio_button: i32,
     color_edit: ColorEditState,
+    custom_rendering: CustomRenderingState,
 }
 
 impl Default for State {
@@ -95,6 +96,7 @@ impl Default for State {
             file_menu: Default::default(),
             radio_button: 0,
             color_edit: ColorEditState::default(),
+            custom_rendering: Default::default(),
         }
     }
 }
@@ -153,6 +155,20 @@ struct AutoResizeState {
 
 impl Default for AutoResizeState {
     fn default() -> Self { AutoResizeState { lines: 10 } }
+}
+
+struct CustomRenderingState {
+    sz: f32,
+    col: [f32; 3],
+}
+
+impl Default for CustomRenderingState {
+    fn default() -> Self {
+        CustomRenderingState {
+            sz: 36.0,
+            col: [1.0, 1.0, 0.4],
+        }
+    }
 }
 
 const CLEAR_COLOR: [f32; 4] = [114.0 / 255.0, 144.0 / 255.0, 154.0 / 255.0, 1.0];
@@ -237,6 +253,14 @@ fn show_test_window(ui: &Ui, state: &mut State, opened: &mut bool) {
                         information.",
                 );
             });
+    }
+
+    if state.show_app_custom_rendering {
+        show_example_app_custom_rendering(
+            ui,
+            &mut state.custom_rendering,
+            &mut state.show_app_custom_rendering,
+        );
     }
 
     ui.window(im_str!("ImGui Demo"))
@@ -741,4 +765,145 @@ My title is the same as window 1, but my identifier is unique.",
     ui.window(title)
         .position((100.0, 300.0), ImGuiCond::FirstUseEver)
         .build(|| ui.text("This window has a changing title"));
+}
+
+fn show_example_app_custom_rendering(ui: &Ui, state: &mut CustomRenderingState, opened: &mut bool) {
+    ui.window(im_str!("Example: Custom rendering"))
+        .size((350.0, 560.0), ImGuiCond::FirstUseEver)
+        .opened(opened)
+        .build(|| {
+            ui.text("Primitives");
+            // TODO: Add DragFloat to change value of sz
+            ui.color_edit(im_str!("Color"), &mut state.col).build();
+            let p = ui.get_cursor_screen_pos();
+            let spacing = 8.0;
+            let mut y = p.1 + 4.0;
+            for n in 0..2 {
+                let mut x = p.0 + 4.0;
+                let thickness = if n == 0 { 1.0 } else { 4.0 };
+                ui.with_window_draw_list(|draw_list| {
+                    draw_list
+                        .add_circle(
+                            (x + state.sz * 0.5, y + state.sz * 0.5),
+                            state.sz * 0.5,
+                            state.col,
+                        )
+                        .num_segments(20)
+                        .thickness(thickness)
+                        .build();
+                    x += state.sz + spacing;
+                    draw_list
+                        .add_rect((x, y), (x + state.sz, y + state.sz), state.col)
+                        .thickness(thickness)
+                        .build();
+                    x += state.sz + spacing;
+                    draw_list
+                        .add_rect((x, y), (x + state.sz, y + state.sz), state.col)
+                        .thickness(thickness)
+                        .rounding(10.0)
+                        .build();
+                    x += state.sz + spacing;
+                    draw_list
+                        .add_rect((x, y), (x + state.sz, y + state.sz), state.col)
+                        .thickness(thickness)
+                        .rounding(10.0)
+                        .round_top_right(false)
+                        .round_bot_left(false)
+                        .build();
+                    x += state.sz + spacing;
+                    draw_list
+                        .add_triangle(
+                            (x + state.sz * 0.5, y),
+                            (x + state.sz, y + state.sz - 0.5),
+                            (x, y + state.sz - 0.5),
+                            state.col,
+                        )
+                        .thickness(thickness)
+                        .build();
+                    x += state.sz + spacing;
+                    draw_list
+                        .add_line((x, y), (x + state.sz, y), state.col)
+                        .thickness(thickness)
+                        .build();
+                    x += state.sz + spacing;
+                    draw_list
+                        .add_line((x, y), (x + state.sz, y + state.sz), state.col)
+                        .thickness(thickness)
+                        .build();
+                    x += state.sz + spacing;
+                    draw_list
+                        .add_line((x, y), (x, y + state.sz), state.col)
+                        .thickness(thickness)
+                        .build();
+                    x += spacing;
+                    draw_list
+                        .add_bezier_curve(
+                            (x, y),
+                            (x + state.sz * 1.3, y + state.sz * 0.3),
+                            (x + state.sz - state.sz * 1.3, y + state.sz - state.sz * 0.3),
+                            (x + state.sz, y + state.sz),
+                            state.col,
+                        )
+                        .thickness(thickness)
+                        .build();
+                });
+                y += state.sz + spacing;
+            }
+            ui.with_window_draw_list(|draw_list| {
+                let mut x = p.0 + 4.0;
+                draw_list
+                    .add_circle(
+                        (x + state.sz * 0.5, y + state.sz * 0.5),
+                        state.sz * 0.5,
+                        state.col,
+                    )
+                    .num_segments(32)
+                    .filled(true)
+                    .build();
+                x += state.sz + spacing;
+                draw_list
+                    .add_rect((x, y), (x + state.sz, y + state.sz), state.col)
+                    .filled(true)
+                    .build();
+                x += state.sz + spacing;
+                draw_list
+                    .add_rect((x, y), (x + state.sz, y + state.sz), state.col)
+                    .filled(true)
+                    .rounding(10.0)
+                    .build();
+                x += state.sz + spacing;
+                draw_list
+                    .add_rect((x, y), (x + state.sz, y + state.sz), state.col)
+                    .filled(true)
+                    .rounding(10.0)
+                    .round_top_right(false)
+                    .round_bot_left(false)
+                    .build();
+                x += state.sz + spacing;
+                draw_list
+                    .add_triangle(
+                        (x + state.sz * 0.5, y),
+                        (x + state.sz, y + state.sz - 0.5),
+                        (x, y + state.sz - 0.5),
+                        state.col,
+                    )
+                    .filled(true)
+                    .build();
+                x += state.sz + spacing;
+                const MULTICOLOR_RECT_CORNER_COLOR1: [f32; 3] = [0.0, 0.0, 0.0];
+                const MULTICOLOR_RECT_CORNER_COLOR2: [f32; 3] = [1.0, 0.0, 0.0];
+                const MULTICOLOR_RECT_CORNER_COLOR3: [f32; 3] = [1.0, 1.0, 0.0];
+                const MULTICOLOR_RECT_CORNER_COLOR4: [f32; 3] = [0.0, 1.0, 0.0];
+                draw_list.add_rect_filled_multicolor(
+                    (x, y),
+                    (x + state.sz, y + state.sz),
+                    MULTICOLOR_RECT_CORNER_COLOR1,
+                    MULTICOLOR_RECT_CORNER_COLOR2,
+                    MULTICOLOR_RECT_CORNER_COLOR3,
+                    MULTICOLOR_RECT_CORNER_COLOR4,
+                );
+            });
+            ui.dummy(((state.sz + spacing) * 8.0, (state.sz + spacing) * 3.0));
+            ui.separator();
+        });
 }

--- a/imgui-sys/src/lib.rs
+++ b/imgui-sys/src/lib.rs
@@ -325,6 +325,26 @@ bitflags!(
     }
 );
 
+bitflags!(
+    /// Flags for indictating which corner of a rectangle should be rounded
+    #[repr(C)]
+    pub struct ImDrawCornerFlags: c_int {
+        const TopLeft  = 1 << 0;
+        const TopRight = 1 << 1;
+        const BotRight = 1 << 2;
+        const BotLeft  = 1 << 3;
+        const Top      = ImDrawCornerFlags::TopLeft.bits
+                       | ImDrawCornerFlags::TopRight.bits;
+        const Bot      = ImDrawCornerFlags::BotLeft.bits
+                       | ImDrawCornerFlags::BotRight.bits;
+        const Left     = ImDrawCornerFlags::TopLeft.bits
+                       | ImDrawCornerFlags::BotLeft.bits;
+        const Right    = ImDrawCornerFlags::TopRight.bits
+                       | ImDrawCornerFlags::BotRight.bits;
+        const All      = 0xF;
+    }
+);
+
 pub type ImGuiTextEditCallback = Option<
     extern "C" fn(data: *mut ImGuiTextEditCallbackData) -> c_int,
 >;
@@ -1840,7 +1860,7 @@ extern "C" {
         b: ImVec2,
         col: ImU32,
         rounding: c_float,
-        rounding_corners_flags: c_int,
+        rounding_corners_flags: ImDrawCornerFlags,
         thickness: c_float,
     );
     pub fn ImDrawList_AddRectFilled(
@@ -1849,7 +1869,7 @@ extern "C" {
         b: ImVec2,
         col: ImU32,
         rounding: c_float,
-        rounding_corners_flags: c_int,
+        rounding_corners_flags: ImDrawCornerFlags,
     );
     pub fn ImDrawList_AddRectFilledMultiColor(
         list: *mut ImDrawList,

--- a/imgui-sys/src/lib.rs
+++ b/imgui-sys/src/lib.rs
@@ -1918,6 +1918,7 @@ extern "C" {
         radius: c_float,
         col: ImU32,
         num_segments: c_int,
+        thickness: c_float,
     );
     pub fn ImDrawList_AddCircleFilled(
         list: *mut ImDrawList,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -537,6 +537,16 @@ impl<'ui> Ui<'ui> {
     pub fn set_cursor_pos<P: Into<ImVec2>>(&self, pos: P) {
         unsafe { sys::igSetCursorPos(pos.into()) }
     }
+
+    /// Get available space left between the cursor and the edges of the current
+    /// window.
+    pub fn get_content_region_avail(&self) -> (f32, f32) {
+        let mut out = ImVec2::new(0.0, 0.0);
+        unsafe {
+            sys::igGetContentRegionAvail(&mut out);
+        }
+        (out.x, out.y)
+    }
 }
 
 // ID scopes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1271,6 +1271,8 @@ impl<'ui> Ui<'ui> {
     /// # Examples
     ///
     /// ```
+    /// # extern crate imgui;
+    /// # use imgui::*;
     /// fn custom_draw(ui: &Ui) {
     ///     ui.with_window_draw_list(|draw_list| {
     ///         // Draw a line

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1274,19 +1274,14 @@ impl<'ui> Ui<'ui> {
     /// ```rust,no_run
     /// # use imgui::*;
     /// fn custom_draw(ui: &Ui) {
-    ///     ui.with_window_draw_list(|draw_list| {
-    ///         // Draw a line
-    ///         const WHITE: [f32; 3] = [1.0, 1.0, 1.0];
-    ///         draw_list.add_line([100.0, 100.0], [200.0, 200.0], WHITE).build();
-    ///         // Continue drawing ...
-    ///     });
+    ///     let draw_list = ui.get_window_draw_list();
+    ///     // Draw a line
+    ///     const WHITE: [f32; 3] = [1.0, 1.0, 1.0];
+    ///     draw_list.add_line([100.0, 100.0], [200.0, 200.0], WHITE).build();
+    ///     // Continue drawing ...
     /// }
     /// ```
-    pub fn with_window_draw_list<F>(&self, f: F)
-    where
-        F: FnOnce(&WindowDrawList),
-    {
-        let window_draw_list = WindowDrawList::new(self);
-        f(&window_draw_list);
+    pub fn get_window_draw_list(&'ui self) -> WindowDrawList<'ui> {
+        WindowDrawList::new(self)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub use string::{ImStr, ImString};
 pub use style::StyleVar;
 pub use trees::{CollapsingHeader, TreeNode};
 pub use window::Window;
-pub use window_draw_list::{ImColor, WindowDrawList};
+pub use window_draw_list::{ImColor, WindowDrawList, ChannelsSplit};
 
 mod child_frame;
 mod color_editors;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -610,6 +610,11 @@ impl<'ui> Ui<'ui> {
     pub fn small_button<'p>(&self, label: &'p ImStr) -> bool {
         unsafe { sys::igSmallButton(label.as_ptr()) }
     }
+    /// Make a invisible event. Can be used to conveniently catch events when
+    /// mouse hovers or click the area covered by this invisible button.
+    pub fn invisible_button<'p, S: Into<ImVec2>>(&self, label: &'p ImStr, size: S) -> bool {
+        unsafe { sys::igInvisibleButton(label.as_ptr(), size.into()) }
+    }
     pub fn checkbox<'p>(&self, label: &'p ImStr, value: &'p mut bool) -> bool {
         unsafe { sys::igCheckbox(label.as_ptr(), value) }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,15 @@ pub fn get_version() -> &'static str {
     }
 }
 
+/// Represents one of the buttons of the mouse
+pub enum ImMouseButton {
+    Left = 0,
+    Right = 1,
+    Middle = 2,
+    Extra1 = 3,
+    Extra2 = 4,
+}
+
 impl ImGui {
     pub fn init() -> ImGui {
         ImGui {
@@ -229,6 +238,25 @@ impl ImGui {
     pub fn mouse_cursor(&self) -> ImGuiMouseCursor {
         unsafe {
             sys::igGetMouseCursor()
+        }
+    }
+    /// Returns `true` if mouse is currently dragging with the `button` provided
+    /// as argument.
+    pub fn is_mouse_dragging(&self, button: ImMouseButton) -> bool {
+        unsafe {
+            sys::igIsMouseDragging(button as c_int, -1.0)
+        }
+    }
+    /// Returns `true` if the `button` provided as argument is currently down.
+    pub fn is_mouse_down(&self, button: ImMouseButton) -> bool {
+        unsafe {
+            sys::igIsMouseDown(button as c_int)
+        }
+    }
+    /// Returns `true` if the `button` provided as argument is being clicked.
+    pub fn is_mouse_clicked(&self, button: ImMouseButton) -> bool {
+        unsafe {
+            sys::igIsMouseClicked(button as c_int, false)
         }
     }
     pub fn key_ctrl(&self) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ pub fn get_version() -> &'static str {
 }
 
 /// Represents one of the buttons of the mouse
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum ImMouseButton {
     Left = 0,
     Right = 1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub use string::{ImStr, ImString};
 pub use style::StyleVar;
 pub use trees::{CollapsingHeader, TreeNode};
 pub use window::Window;
+pub use window_draw_list::{ImColor, WindowDrawList};
 
 mod child_frame;
 mod color_editors;
@@ -41,6 +42,7 @@ mod string;
 mod style;
 mod trees;
 mod window;
+mod window_draw_list;
 
 pub struct ImGui {
     // We need to keep ownership of the ImStr values to ensure the *const char pointer
@@ -1209,5 +1211,30 @@ impl<'ui> Ui<'ui> {
         unsafe { sys::igBeginGroup(); }
         f();
         unsafe { sys::igEndGroup(); }
+    }
+}
+
+/// # Draw list for custom drawing
+impl<'ui> Ui<'ui> {
+    /// Get access to drawing API
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// fn custom_draw(ui: &Ui) {
+    ///     ui.with_window_draw_list(|draw_list| {
+    ///         // Draw a line
+    ///         const WHITE: [f32; 3] = [1.0, 1.0, 1.0];
+    ///         draw_list.add_line([100.0, 100.0], [200.0, 200.0], WHITE).build();
+    ///         // Continue drawing ...
+    ///     });
+    /// }
+    /// ```
+    pub fn with_window_draw_list<F>(&self, f: F)
+    where
+        F: FnOnce(&WindowDrawList),
+    {
+        let window_draw_list = WindowDrawList::new(self);
+        f(&window_draw_list);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -469,6 +469,13 @@ impl<'ui> Ui<'ui> {
 
     pub fn get_columns_count(&self) -> i32 { unsafe { sys::igGetColumnsCount() } }
 
+    /// Fill a space of `size` in pixels with nothing on the current window.
+    /// Can be used to move the cursor on the window.
+    pub fn dummy<S: Into<ImVec2>>(&self, size: S) {
+        let size = size.into();
+        unsafe { sys::igDummy(&size) }
+    }
+
     /// Get cursor position on the screen, in screen coordinates.
     /// This sets the point on which the next widget will be drawn.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1270,8 +1270,7 @@ impl<'ui> Ui<'ui> {
     ///
     /// # Examples
     ///
-    /// ```
-    /// # extern crate imgui;
+    /// ```rust,no_run
     /// # use imgui::*;
     /// fn custom_draw(ui: &Ui) {
     ///     ui.with_window_draw_list(|draw_list| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1281,6 +1281,21 @@ impl<'ui> Ui<'ui> {
     ///     // Continue drawing ...
     /// }
     /// ```
+    ///
+    /// This function will panic if several instances of [`WindowDrawList`]
+    /// coexist. Before a new instance is got, a previous instance should be
+    /// dropped.
+    ///
+    /// ```rust
+    /// # use imgui::*;
+    /// fn custom_draw(ui: &Ui) {
+    ///     let draw_list = ui.get_window_draw_list();
+    ///     // Draw something...
+    ///
+    ///     // This second call will panic!
+    ///     let draw_list = ui.get_window_draw_list();
+    /// }
+    /// ```
     pub fn get_window_draw_list(&'ui self) -> WindowDrawList<'ui> {
         WindowDrawList::new(self)
     }

--- a/src/window_draw_list.rs
+++ b/src/window_draw_list.rs
@@ -74,7 +74,7 @@ impl<'ui> WindowDrawList<'ui> {
     /// Split into *channels_count* drawing channels.
     /// At the end of the closure, the channels are merged. The objects
     /// are then drawn in the increasing order of their channel number, and not
-    /// in the all order they were called.
+    /// in the order they were called.
     ///
     /// # Example
     ///
@@ -100,7 +100,9 @@ impl<'ui> WindowDrawList<'ui> {
     }
 }
 
-/// Represent the drawing interface within a call to `channels_split`.
+/// Represent the drawing interface within a call to [`channels_split`].
+///
+/// [`channels_split`]: WindowDrawList::channels_split
 pub struct ChannelsSplit<'ui> {
     draw_list: &'ui WindowDrawList<'ui>,
     channels_count: u32,
@@ -111,7 +113,7 @@ impl<'ui> DrawAPI for ChannelsSplit<'ui> {
 }
 
 impl<'ui> ChannelsSplit<'ui> {
-    /// Change current channel
+    /// Change current channel.
     ///
     /// Panic if channel_index overflows the number of channels.
     pub fn channels_set_current(&self, channel_index: u32) {

--- a/src/window_draw_list.rs
+++ b/src/window_draw_list.rs
@@ -79,6 +79,8 @@ impl<'ui> WindowDrawList<'ui> {
     /// # Example
     ///
     /// ```
+    /// # extern crate imgui;
+    /// # use imgui::*;
     /// fn custom_drawing(ui: &Ui) {
     ///     ui.with_window_draw_list(|draw_list| {
     ///         draw_list.channels_split(2, |draw_list| {

--- a/src/window_draw_list.rs
+++ b/src/window_draw_list.rs
@@ -81,13 +81,12 @@ impl<'ui> WindowDrawList<'ui> {
     /// ```rust,no_run
     /// # use imgui::*;
     /// fn custom_drawing(ui: &Ui) {
-    ///     ui.with_window_draw_list(|draw_list| {
-    ///         draw_list.channels_split(2, |draw_list| {
-    ///             draw_list.channels_set_current(1);
-    ///             // ... Draw channel 1
-    ///             draw_list.channels_set_current(0);
-    ///             // ... Draw channel 0
-    ///         });
+    ///     let draw_list = ui.get_window_draw_list();
+    ///     draw_list.channels_split(2, |draw_list| {
+    ///         draw_list.channels_set_current(1);
+    ///         // ... Draw channel 1
+    ///         draw_list.channels_set_current(0);
+    ///         // ... Draw channel 0
     ///     });
     /// }
     /// ```

--- a/src/window_draw_list.rs
+++ b/src/window_draw_list.rs
@@ -48,7 +48,7 @@ impl From<(f32, f32, f32)> for ImColor {
 /// All types from which ImGui's custom draw API can be used implement this
 /// trait. This trait is internal to this library and implemented by
 /// `WindowDrawList` and `ChannelsSplit`.
-pub trait DrawAPI<'ui> {
+pub trait DrawAPI {
     /// Get draw_list object
     fn draw_list(&self) -> *mut ImDrawList;
 }
@@ -59,7 +59,7 @@ pub struct WindowDrawList<'ui> {
     _phantom: PhantomData<&'ui Ui<'ui>>,
 }
 
-impl<'ui> DrawAPI<'ui> for WindowDrawList<'ui> {
+impl<'ui> DrawAPI for WindowDrawList<'ui> {
     fn draw_list(&self) -> *mut ImDrawList { self.draw_list }
 }
 
@@ -101,7 +101,7 @@ impl<'ui> WindowDrawList<'ui> {
 /// Represent the drawing interface within a call to `channels_split`.
 pub struct ChannelsSplit<'ui>(&'ui WindowDrawList<'ui>);
 
-impl<'ui> DrawAPI<'ui> for ChannelsSplit<'ui> {
+impl<'ui> DrawAPI for ChannelsSplit<'ui> {
     fn draw_list(&self) -> *mut ImDrawList { self.0.draw_list }
 }
 
@@ -116,7 +116,7 @@ macro_rules! impl_draw_list_methods {
     ($T: ident) => {
         impl<'ui> $T<'ui>
         where
-            $T<'ui>: DrawAPI<'ui>,
+            $T<'ui>: DrawAPI,
         {
             /// Returns a line from point `p1` to `p2` with color `c`.
             pub fn add_line<P1, P2, C>(&self, p1: P1, p2: P2, c: C) -> Line<'ui, $T>
@@ -270,7 +270,7 @@ pub struct Line<'ui, D: 'ui> {
     draw_list: &'ui D,
 }
 
-impl<'ui, D: DrawAPI<'ui>> Line<'ui, D> {
+impl<'ui, D: DrawAPI> Line<'ui, D> {
     fn new<P1, P2, C>(draw_list: &'ui D, p1: P1, p2: P2, c: C) -> Self
     where
         P1: Into<ImVec2>,
@@ -318,7 +318,7 @@ pub struct Rect<'ui, D: 'ui> {
     draw_list: &'ui D,
 }
 
-impl<'ui, D: DrawAPI<'ui>> Rect<'ui, D> {
+impl<'ui, D: DrawAPI> Rect<'ui, D> {
     fn new<P1, P2, C>(draw_list: &'ui D, p1: P1, p2: P2, c: C) -> Self
     where
         P1: Into<ImVec2>,
@@ -420,7 +420,7 @@ pub struct Triangle<'ui, D: 'ui> {
     draw_list: &'ui D,
 }
 
-impl<'ui, D: DrawAPI<'ui>> Triangle<'ui, D> {
+impl<'ui, D: DrawAPI> Triangle<'ui, D> {
     fn new<P1, P2, P3, C>(draw_list: &'ui D, p1: P1, p2: P2, p3: P3, c: C) -> Self
     where
         P1: Into<ImVec2>,
@@ -489,7 +489,7 @@ pub struct Circle<'ui, D: 'ui> {
     draw_list: &'ui D,
 }
 
-impl<'ui, D: DrawAPI<'ui>> Circle<'ui, D> {
+impl<'ui, D: DrawAPI> Circle<'ui, D> {
     pub fn new<P, C>(draw_list: &'ui D, center: P, radius: f32, color: C) -> Self
     where
         P: Into<ImVec2>,
@@ -565,7 +565,7 @@ pub struct BezierCurve<'ui, D: 'ui> {
     draw_list: &'ui D,
 }
 
-impl<'ui, D: DrawAPI<'ui>> BezierCurve<'ui, D> {
+impl<'ui, D: DrawAPI> BezierCurve<'ui, D> {
     fn new<P1, P2, P3, P4, C>(draw_list: &'ui D, pos0: P1, cp0: P2, cp1: P3, pos1: P4, c: C) -> Self
     where
         P1: Into<ImVec2>,

--- a/src/window_draw_list.rs
+++ b/src/window_draw_list.rs
@@ -218,6 +218,41 @@ macro_rules! impl_draw_list_methods {
             {
                 BezierCurve::new(self, pos0, cp0, cp1, pos1, color)
             }
+
+            /// Push a clipping rectangle on the stack, run `f` and pop it.
+            ///
+            /// Clip all drawings done within the closure `f` in the given
+            /// rectangle.
+            pub fn with_clip_rect<P1, P2, F>(&self, min: P1, max: P2, f: F)
+            where
+                P1: Into<ImVec2>,
+                P2: Into<ImVec2>,
+                F: FnOnce(),
+            {
+                unsafe {
+                    sys::ImDrawList_PushClipRect(self.draw_list(), min.into(), max.into(), false)
+                }
+                f();
+                unsafe { sys::ImDrawList_PopClipRect(self.draw_list()) }
+            }
+
+            /// Push a clipping rectangle on the stack, run `f` and pop it.
+            ///
+            /// Clip all drawings done within the closure `f` in the given
+            /// rectangle. Intersect with all clipping rectangle previously on
+            /// the stack.
+            pub fn with_clip_rect_intersect<P1, P2, F>(&self, min: P1, max: P2, f: F)
+            where
+                P1: Into<ImVec2>,
+                P2: Into<ImVec2>,
+                F: FnOnce(),
+            {
+                unsafe {
+                    sys::ImDrawList_PushClipRect(self.draw_list(), min.into(), max.into(), true)
+                }
+                f();
+                unsafe { sys::ImDrawList_PopClipRect(self.draw_list()) }
+            }
         }
     };
 }

--- a/src/window_draw_list.rs
+++ b/src/window_draw_list.rs
@@ -172,6 +172,24 @@ macro_rules! impl_draw_list_methods {
                 }
             }
 
+            /// Returns a triangle with the given 3 vertices `p1`, `p2` and `p3`
+            /// and color `c`.
+            pub fn add_triangle<P1, P2, P3, C>(
+                &self,
+                p1: P1,
+                p2: P2,
+                p3: P3,
+                c: C,
+            ) -> Triangle<'ui, $T>
+            where
+                P1: Into<ImVec2>,
+                P2: Into<ImVec2>,
+                P3: Into<ImVec2>,
+                C: Into<ImColor>,
+            {
+                Triangle::new(self, p1, p2, p3, c)
+            }
+
             /// Returns a circle with the given `center`, `radius` and `color`.
             pub fn add_circle<P, C>(&self, center: P, radius: f32, color: C) -> Circle<'ui, $T>
             where
@@ -330,6 +348,75 @@ impl<'ui, D: DrawAPI<'ui>> Rect<'ui, D> {
                     self.flags,
                     self.thickness,
                 );
+            }
+        }
+    }
+}
+
+/// Represents a circle about to be drawn on the window
+pub struct Triangle<'ui, D: 'ui> {
+    p1: ImVec2,
+    p2: ImVec2,
+    p3: ImVec2,
+    color: ImColor,
+    thickness: f32,
+    filled: bool,
+    draw_list: &'ui D,
+}
+
+impl<'ui, D: DrawAPI<'ui>> Triangle<'ui, D> {
+    fn new<P1, P2, P3, C>(draw_list: &'ui D, p1: P1, p2: P2, p3: P3, c: C) -> Self
+    where
+        P1: Into<ImVec2>,
+        P2: Into<ImVec2>,
+        P3: Into<ImVec2>,
+        C: Into<ImColor>,
+    {
+        Self {
+            p1: p1.into(),
+            p2: p2.into(),
+            p3: p3.into(),
+            color: c.into(),
+            thickness: 1.0,
+            filled: false,
+            draw_list,
+        }
+    }
+
+    /// Set triangle's thickness (default to 1.0 pixel)
+    pub fn thickness(mut self, thickness: f32) -> Self {
+        self.thickness = thickness;
+        self
+    }
+
+    /// Set to `true` to make a filled triangle (default to `false`).
+    pub fn filled(mut self, filled: bool) -> Self {
+        self.filled = filled;
+        self
+    }
+
+    /// Draw the triangle on the window.
+    pub fn build(self) {
+        if self.filled {
+            unsafe {
+                sys::ImDrawList_AddTriangleFilled(
+                    self.draw_list.draw_list(),
+                    self.p1,
+                    self.p2,
+                    self.p3,
+                    self.color.into(),
+                )
+            }
+        } else {
+            unsafe {
+                sys::ImDrawList_AddTriangle(
+                    self.draw_list.draw_list(),
+                    self.p1,
+                    self.p2,
+                    self.p3,
+                    self.color.into(),
+                    self.thickness,
+                )
             }
         }
     }

--- a/src/window_draw_list.rs
+++ b/src/window_draw_list.rs
@@ -1,0 +1,179 @@
+use sys;
+use sys::{ImDrawList, ImU32};
+
+use super::{ImVec2, ImVec4, Ui};
+
+use std::marker::PhantomData;
+
+/// Wrap `ImU32` (a type typically used by ImGui to store packed colors)
+/// This type is used to represent the color of drawing primitives in ImGui's
+/// custom drawing API.
+///
+/// The type implements `From<ImU32>`, `From<ImVec4>`, `From<[f32; 4]>`,
+/// `From<[f32; 3]>`, `From<(f32, f32, f32, f32)>` and `From<(f32, f32, f32)>`
+/// for convenience. If alpha is not provided, it is assumed to be 1.0 (255).
+#[derive(Copy, Clone)]
+pub struct ImColor(ImU32);
+
+impl From<ImColor> for ImU32 {
+    fn from(color: ImColor) -> Self { color.0 }
+}
+
+impl From<ImU32> for ImColor {
+    fn from(color: ImU32) -> Self { ImColor(color) }
+}
+
+impl From<ImVec4> for ImColor {
+    fn from(v: ImVec4) -> Self { ImColor(unsafe { sys::igColorConvertFloat4ToU32(v) }) }
+}
+
+impl From<[f32; 4]> for ImColor {
+    fn from(v: [f32; 4]) -> Self { ImColor(unsafe { sys::igColorConvertFloat4ToU32(v.into()) }) }
+}
+
+impl From<(f32, f32, f32, f32)> for ImColor {
+    fn from(v: (f32, f32, f32, f32)) -> Self {
+        ImColor(unsafe { sys::igColorConvertFloat4ToU32(v.into()) })
+    }
+}
+
+impl From<[f32; 3]> for ImColor {
+    fn from(v: [f32; 3]) -> Self { [v[0], v[1], v[2], 1.0].into() }
+}
+
+impl From<(f32, f32, f32)> for ImColor {
+    fn from(v: (f32, f32, f32)) -> Self { [v.0, v.1, v.2, 1.0].into() }
+}
+
+/// All types from which ImGui's custom draw API can be used implement this
+/// trait. This trait is internal to this library and implemented by
+/// `WindowDrawList` and `ChannelsSplit`.
+pub trait DrawAPI<'ui> {
+    /// Get draw_list object
+    fn draw_list(&self) -> *mut ImDrawList;
+}
+
+/// Object implementing the custom draw API.
+pub struct WindowDrawList<'ui> {
+    draw_list: *mut ImDrawList,
+    _phantom: PhantomData<&'ui Ui<'ui>>,
+}
+
+impl<'ui> DrawAPI<'ui> for WindowDrawList<'ui> {
+    fn draw_list(&self) -> *mut ImDrawList { self.draw_list }
+}
+
+impl<'ui> WindowDrawList<'ui> {
+    pub fn new(_: &Ui<'ui>) -> Self {
+        Self {
+            draw_list: unsafe { sys::igGetWindowDrawList() },
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Split into *channels_count* drawing channels.
+    /// At the end of the closure, the channels are merged. The objects
+    /// are then drawn in the increasing order of their channel number, and not
+    /// in the all order they were called.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// fn custom_drawing(ui: &Ui) {
+    ///     ui.with_window_draw_list(|draw_list| {
+    ///         draw_list.channels_split(2, |draw_list| {
+    ///             draw_list.channels_set_current(1);
+    ///             // ... Draw channel 1
+    ///             draw_list.channels_set_current(0);
+    ///             // ... Draw channel 0
+    ///         });
+    ///     });
+    /// }
+    /// ```
+    pub fn channels_split<F: FnOnce(&ChannelsSplit)>(&self, channels_count: u32, f: F) {
+        unsafe { sys::ImDrawList_ChannelsSplit(self.draw_list, channels_count as i32) };
+        f(&ChannelsSplit(self));
+        unsafe { sys::ImDrawList_ChannelsMerge(self.draw_list) };
+    }
+}
+
+/// Represent the drawing interface within a call to `channels_split`.
+pub struct ChannelsSplit<'ui>(&'ui WindowDrawList<'ui>);
+
+impl<'ui> DrawAPI<'ui> for ChannelsSplit<'ui> {
+    fn draw_list(&self) -> *mut ImDrawList { self.0.draw_list }
+}
+
+impl<'ui> ChannelsSplit<'ui> {
+    /// Change current channel
+    pub fn channels_set_current(&self, channel_index: u32) {
+        unsafe { sys::ImDrawList_ChannelsSetCurrent(self.draw_list(), channel_index as i32) };
+    }
+}
+
+macro_rules! impl_draw_list_methods {
+    ($T: ident) => {
+        impl<'ui> $T<'ui>
+        where
+            $T<'ui>: DrawAPI<'ui>,
+        {
+            /// Returns a line from point `p1` to `p2` with color `c`.
+            pub fn add_line<P1, P2, C>(&self, p1: P1, p2: P2, c: C) -> Line<'ui, $T>
+            where
+                P1: Into<ImVec2>,
+                P2: Into<ImVec2>,
+                C: Into<ImColor>,
+            {
+                Line::new(self, p1, p2, c)
+            }
+        }
+    };
+}
+
+impl_draw_list_methods!(WindowDrawList);
+impl_draw_list_methods!(ChannelsSplit);
+
+/// Represents a line about to be drawn
+pub struct Line<'ui, D: 'ui> {
+    p1: ImVec2,
+    p2: ImVec2,
+    color: ImColor,
+    thickness: f32,
+    draw_list: &'ui D,
+}
+
+impl<'ui, D: DrawAPI<'ui>> Line<'ui, D> {
+    fn new<P1, P2, C>(draw_list: &'ui D, p1: P1, p2: P2, c: C) -> Self
+    where
+        P1: Into<ImVec2>,
+        P2: Into<ImVec2>,
+        C: Into<ImColor>,
+    {
+        Self {
+            p1: p1.into(),
+            p2: p2.into(),
+            color: c.into(),
+            thickness: 1.0,
+            draw_list,
+        }
+    }
+
+    /// Set line's thickness (default to 1.0 pixel)
+    pub fn thickness(mut self, thickness: f32) -> Self {
+        self.thickness = thickness;
+        self
+    }
+
+    /// Draw the line on the window
+    pub fn build(self) {
+        unsafe {
+            sys::ImDrawList_AddLine(
+                self.draw_list.draw_list(),
+                self.p1,
+                self.p2,
+                self.color.into(),
+                self.thickness,
+            )
+        }
+    }
+}

--- a/src/window_draw_list.rs
+++ b/src/window_draw_list.rs
@@ -409,7 +409,7 @@ impl<'ui, D: DrawAPI<'ui>> Rect<'ui, D> {
     }
 }
 
-/// Represents a circle about to be drawn on the window
+/// Represents a triangle about to be drawn on the window
 pub struct Triangle<'ui, D: 'ui> {
     p1: ImVec2,
     p2: ImVec2,

--- a/src/window_draw_list.rs
+++ b/src/window_draw_list.rs
@@ -64,7 +64,7 @@ impl<'ui> DrawAPI for WindowDrawList<'ui> {
 }
 
 impl<'ui> WindowDrawList<'ui> {
-    pub fn new(_: &Ui<'ui>) -> Self {
+    pub(crate) fn new(_: &Ui<'ui>) -> Self {
         Self {
             draw_list: unsafe { sys::igGetWindowDrawList() },
             _phantom: PhantomData,

--- a/src/window_draw_list.rs
+++ b/src/window_draw_list.rs
@@ -78,8 +78,7 @@ impl<'ui> WindowDrawList<'ui> {
     ///
     /// # Example
     ///
-    /// ```
-    /// # extern crate imgui;
+    /// ```rust,no_run
     /// # use imgui::*;
     /// fn custom_drawing(ui: &Ui) {
     ///     ui.with_window_draw_list(|draw_list| {

--- a/src/window_draw_list.rs
+++ b/src/window_draw_list.rs
@@ -12,7 +12,7 @@ use std::marker::PhantomData;
 /// The type implements `From<ImU32>`, `From<ImVec4>`, `From<[f32; 4]>`,
 /// `From<[f32; 3]>`, `From<(f32, f32, f32, f32)>` and `From<(f32, f32, f32)>`
 /// for convenience. If alpha is not provided, it is assumed to be 1.0 (255).
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub struct ImColor(ImU32);
 
 impl From<ImColor> for ImU32 {

--- a/src/window_draw_list.rs
+++ b/src/window_draw_list.rs
@@ -137,6 +137,40 @@ macro_rules! impl_draw_list_methods {
             {
                 Rect::new(self, p1, p2, c)
             }
+
+            /// Draw a rectangle whose upper-left corner is at point `p1`
+            /// and lower-right corner is at point `p2`.
+            /// The remains parameters are the respective color of the corners
+            /// in the counter-clockwise starting from the upper-left corner
+            /// first.
+            pub fn add_rect_filled_multicolor<P1, P2, C1, C2, C3, C4>(
+                &self,
+                p1: P1,
+                p2: P2,
+                col_upr_left: C1,
+                col_upr_right: C2,
+                col_bot_right: C3,
+                col_bot_left: C4,
+            ) where
+                P1: Into<ImVec2>,
+                P2: Into<ImVec2>,
+                C1: Into<ImColor>,
+                C2: Into<ImColor>,
+                C3: Into<ImColor>,
+                C4: Into<ImColor>,
+            {
+                unsafe {
+                    sys::ImDrawList_AddRectFilledMultiColor(
+                        self.draw_list(),
+                        p1.into(),
+                        p2.into(),
+                        col_upr_left.into().into(),
+                        col_upr_right.into().into(),
+                        col_bot_right.into().into(),
+                        col_bot_left.into().into(),
+                    );
+                }
+            }
         }
     };
 }

--- a/src/window_draw_list.rs
+++ b/src/window_draw_list.rs
@@ -100,10 +100,10 @@ impl<'ui> WindowDrawList<'ui> {
     /// # use imgui::*;
     /// fn custom_drawing(ui: &Ui) {
     ///     let draw_list = ui.get_window_draw_list();
-    ///     draw_list.channels_split(2, |draw_list| {
-    ///         draw_list.channels_set_current(1);
+    ///     draw_list.channels_split(2, |channels| {
+    ///         channels.set_current(1);
     ///         // ... Draw channel 1
-    ///         draw_list.channels_set_current(0);
+    ///         channels.set_current(0);
     ///         // ... Draw channel 0
     ///     });
     /// }
@@ -134,7 +134,7 @@ impl<'ui> ChannelsSplit<'ui> {
     /// Change current channel.
     ///
     /// Panic if channel_index overflows the number of channels.
-    pub fn channels_set_current(&self, channel_index: u32) {
+    pub fn set_current(&self, channel_index: u32) {
         assert!(
             channel_index < self.channels_count,
             "Channel cannot be set! Provided channel index ({}) is higher than channel count ({}).",


### PR DESCRIPTION
This is an attempt at wrapping ImGui's custom drawing API.

The custom rendering example provided with ImGui has been completely implemented. The result is as below:

![image](https://user-images.githubusercontent.com/14120117/38121629-8534a0ea-340b-11e8-9656-b7f79ae4a614.png)

Each patch should be self-explanatory and can be reviewed separately.

This collection of patches can be split into 4 sections.
- Implementation of `window_draw_list.rs`, the API itself
- Add a few helper methods in `Ui`. These functions will be used for the examples.
- Add `show_example_app_custom_rendering` in `test_window_impl`
- Add another example `test_drawing_channels_split`, showing how channels_split can be used. => The example can be removed from this PR if you do not like it.

This is an improvement over #102. With support for safe use of `channels_split` and generics to allow a more convenient use of the API.