### PR TITLE
imgui-glium-renderer: export glium and imgui crate

### DIFF
--- a/imgui-glium-renderer/Cargo.toml
+++ b/imgui-glium-renderer/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/Gekkio/imgui-rs"
 license = "MIT/Apache-2.0"
 categories = ["gui", "rendering"]
 
+[features]
+reexport-depts = []
+
 [badges]
 travis-ci = { repository = "Gekkio/imgui-rs" }
 

--- a/imgui-glium-renderer/Cargo.toml
+++ b/imgui-glium-renderer/Cargo.toml
@@ -12,6 +12,6 @@ categories = ["gui", "rendering"]
 travis-ci = { repository = "Gekkio/imgui-rs" }
 
 [dependencies]
-glium = { version = "0.21", default-features = false }
+glium = { version = "0.21" }
 imgui = { version = "0.0.19-pre", path = "../" }
 imgui-sys = { version = "0.0.19-pre", path = "../imgui-sys", features = ["glium"] }

--- a/imgui-glium-renderer/src/lib.rs
+++ b/imgui-glium-renderer/src/lib.rs
@@ -1,6 +1,14 @@
 #[macro_use]
+#[cfg(feature = "reexport-depts")]
 pub extern crate glium;
+#[cfg(feature = "reexport-depts")]
 pub extern crate imgui;
+
+#[macro_use]
+#[cfg(not(feature = "reexport-depts"))]
+extern crate glium;
+#[cfg(not(feature = "reexport-depts"))]
+extern crate imgui;
 
 use glium::{DrawError, GlObject, IndexBuffer, Program, Surface, Texture2d, VertexBuffer};
 use glium::backend::{Context, Facade};

--- a/imgui-glium-renderer/src/lib.rs
+++ b/imgui-glium-renderer/src/lib.rs
@@ -1,6 +1,6 @@
 #[macro_use]
-extern crate glium;
-extern crate imgui;
+pub extern crate glium;
+pub extern crate imgui;
 
 use glium::{DrawError, GlObject, IndexBuffer, Program, Surface, Texture2d, VertexBuffer};
 use glium::backend::{Context, Facade};


### PR DESCRIPTION
This exports the glium and imgui crates found in the glium-renderer.

This should help glium-renderer users avoid library version conflicts by having them use
```rust
use imgui_glium_renderer::glium;
use imgui_glium_renderer::imgui;
```

I have also removed `default-features = false` as it was causing undefined references to `glium::glutin`.