### PR TITLE
Custom texture support for glium back-end

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,9 @@ travis-ci = { repository = "Gekkio/imgui-rs" }
 [dependencies]
 imgui-sys = { version = "0.0.19-pre", path = "imgui-sys" }
 
+[dev-dependencies]
+glium = { version = "0.21", default-features = true }
+imgui-glium-renderer = { path = "imgui-glium-renderer" }
+
 [workspace]
 members = ["imgui-examples", "imgui-sys", "imgui-gfx-renderer", "imgui-glium-renderer"]

--- a/imgui-examples/examples/custom_textures.rs
+++ b/imgui-examples/examples/custom_textures.rs
@@ -1,0 +1,85 @@
+extern crate glium;
+#[macro_use]
+extern crate imgui;
+extern crate imgui_glium_renderer;
+
+mod support_custom_textures;
+
+use glium::backend::Facade;
+use glium::{Surface, Texture2d};
+use imgui::{FromImTexture, ImGuiCond, ImTexture};
+use imgui_glium_renderer::Texture;
+
+use support_custom_textures::AppContext;
+
+fn main() {
+    let mut app = AppContext::init("custom_texture.rs".to_owned(), Default::default()).unwrap();
+    let font_id = app.imgui_mut().fonts().get_id();
+    let font_size = app.imgui_mut().fonts().get_size();
+
+    let gl_ctx = app.get_context().clone();
+    let mut t = 0.0;
+
+    app.run(|ui| {
+        ui.window(im_str!("Custom texture"))
+            .size((300.0, 400.0), ImGuiCond::FirstUseEver)
+            .build(|| {
+                // Font texture
+                ui.text("Font texture");
+                ui.image(&font_id, (font_size.0 as f32, font_size.1 as f32))
+                    .build();
+
+                // Constant texture (define once)
+                ui.text("Constant texture");
+                let constant_texture = ui.make_texture(im_str!("#Constant"), || {
+                    let mut image_data: Vec<Vec<(f32, f32, f32, f32)>> = Vec::new();
+                    for i in 0..100 {
+                        let mut row: Vec<(f32, f32, f32, f32)> = Vec::new();
+                        for j in 0..100 {
+                            row.push((i as f32 / 100.0, j as f32 / 100.0, 0.0, 1.0));
+                        }
+                        image_data.push(row);
+                    }
+                    Texture2d::new(&gl_ctx, image_data).unwrap()
+                });
+                let size = constant_texture.get_size();
+                ui.image(&constant_texture, (size.0 as f32, size.1 as f32))
+                    .build();
+
+                // Changing texture (re-defined and swap texture for each frame)
+                ui.text("Variable texture");
+                let changing_texture = ui.replace_texture(im_str!("#Changing"), {
+                    let mut image_data: Vec<Vec<(f32, f32, f32, f32)>> = Vec::new();
+                    for i in 0..100 {
+                        let mut row: Vec<(f32, f32, f32, f32)> = Vec::new();
+                        for j in 0..100 {
+                            row.push((i as f32 / 100.0, j as f32 / 100.0, t, 1.0));
+                        }
+                        image_data.push(row);
+                    }
+                    t += 0.01;
+                    if t > 1.0 {
+                        t = 0.0;
+                    }
+                    Texture2d::new(&gl_ctx, image_data).unwrap()
+                });
+                let size = changing_texture.get_size();
+                ui.image(&changing_texture, (size.0 as f32, size.1 as f32))
+                    .build();
+
+                // Texture defined only once, however, you can dynamically draw on it.
+                ui.text("Draw on texture");
+                let draw_texture = ui.make_texture(im_str!("#Draw"), || {
+                    Texture2d::empty(&gl_ctx, 100, 100).unwrap()
+                });
+                // Get the texture as a surface. It must first be converted to a
+                // `glium::Texture2d` object by using `Texture::from`.
+                let mut surface = Texture::from_im_texture(&draw_texture).as_surface();
+                surface.clear_color(1.0, 0.0, 0.0, 1.0);
+                let size = draw_texture.get_size();
+                ui.image(&draw_texture, (size.0 as f32, size.1 as f32))
+                    .build();
+            });
+        true
+    }).unwrap();
+}

--- a/imgui-examples/examples/support_custom_textures/mod.rs
+++ b/imgui-examples/examples/support_custom_textures/mod.rs
@@ -1,0 +1,285 @@
+use std::cell::Ref;
+use std::rc::Rc;
+use std::time::Instant;
+
+use glium::backend::glutin::DisplayCreationError;
+use glium::backend::{Context, Facade};
+use glium::{glutin, Display, Surface, SwapBuffersError};
+
+use imgui::{ImGui, ImGuiMouseCursor, ImString, Ui};
+use imgui_glium_renderer::{Renderer, RendererError};
+
+#[derive(Copy, Clone, PartialEq, Debug, Default)]
+struct MouseState {
+    pos: (i32, i32),
+    pressed: (bool, bool, bool),
+    wheel: f32,
+}
+
+pub struct AppContext {
+    renderer: Renderer,
+    display: Display,
+    events_loop: glutin::EventsLoop,
+    imgui: ImGui,
+    quit: bool,
+    mouse_state: MouseState,
+    last_frame: Instant,
+    clear_color: [f32; 4],
+}
+
+#[derive(Debug)]
+pub enum ContextError {
+    Glutin(DisplayCreationError),
+    Render(RendererError),
+    SwapBuffers(SwapBuffersError),
+    Message(String),
+}
+
+impl From<DisplayCreationError> for ContextError {
+    fn from(e: DisplayCreationError) -> Self { ContextError::Glutin(e) }
+}
+
+impl From<RendererError> for ContextError {
+    fn from(e: RendererError) -> Self { ContextError::Render(e) }
+}
+
+impl From<SwapBuffersError> for ContextError {
+    fn from(e: SwapBuffersError) -> Self { ContextError::SwapBuffers(e) }
+}
+
+#[derive(Clone, Debug)]
+pub struct AppConfig {
+    pub clear_color: [f32; 4],
+    pub ini_filename: Option<ImString>,
+    pub log_filename: Option<ImString>,
+    pub window_width: u32,
+    pub window_height: u32,
+}
+
+impl Default for AppConfig {
+    fn default() -> Self {
+        Self {
+            clear_color: [1.0, 1.0, 1.0, 1.0],
+            ini_filename: None,
+            log_filename: None,
+            window_width: 1024,
+            window_height: 768,
+        }
+    }
+}
+
+impl Facade for AppContext {
+    fn get_context(&self) -> &Rc<Context> { self.display.get_context() }
+}
+
+impl AppContext {
+    pub fn init(title: String, config: AppConfig) -> Result<Self, ContextError> {
+        let events_loop = glutin::EventsLoop::new();
+        let context = glutin::ContextBuilder::new().with_vsync(true);
+        let window = glutin::WindowBuilder::new()
+            .with_title(title)
+            .with_dimensions(config.window_width, config.window_height);
+        let display = Display::new(window, context, &events_loop)?;
+        let mut imgui = ImGui::init();
+        imgui.set_ini_filename(config.ini_filename);
+        imgui.set_log_filename(config.log_filename);
+
+        let renderer = Renderer::init(&mut imgui, &display)?;
+
+        configure_keys(&mut imgui);
+
+        Ok(AppContext {
+            renderer,
+            display,
+            events_loop,
+            imgui,
+            quit: false,
+            mouse_state: Default::default(),
+            last_frame: Instant::now(),
+            clear_color: config.clear_color,
+        })
+    }
+
+    pub fn run<F: FnMut(&Ui) -> bool>(&mut self, mut run_ui: F) -> Result<(), ContextError> {
+        loop {
+            self.poll_events();
+            let now = Instant::now();
+            let delta = now - self.last_frame;
+            let delta_s = delta.as_secs() as f32 + delta.subsec_nanos() as f32 / 1_000_000_000.0;
+            update_mouse(&mut self.imgui, &mut self.mouse_state);
+            let gl_window = self.display.gl_window();
+
+            update_os_cursor(&self.imgui, &gl_window);
+
+            let size_pixels = gl_window
+                .get_inner_size()
+                .ok_or_else(|| ContextError::Message("Window no longer exists!".to_owned()))?;
+            let hdipi = gl_window.hidpi_factor();
+            let size_points = (
+                (size_pixels.0 as f32 / hdipi) as u32,
+                (size_pixels.1 as f32 / hdipi) as u32,
+            );
+
+            let ui = self.imgui.frame(size_points, size_pixels, delta_s);
+            if !run_ui(&ui) {
+                break;
+            }
+            let mut target = self.display.draw();
+            target.clear_color(
+                self.clear_color[0],
+                self.clear_color[1],
+                self.clear_color[2],
+                self.clear_color[3],
+            );
+            self.renderer.render(&mut target, ui)?;
+            target.finish()?;
+
+            if self.quit {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    fn poll_events(&mut self) {
+        let quit = &mut self.quit;
+        let imgui = &mut self.imgui;
+        let events_loop = &mut self.events_loop;
+        let mouse_state = &mut self.mouse_state;
+        events_loop.poll_events(|event| {
+            use glium::glutin::ElementState::Pressed;
+            use glium::glutin::WindowEvent::*;
+            use glium::glutin::{Event, MouseButton, MouseScrollDelta, TouchPhase};
+
+            if let Event::WindowEvent { event, .. } = event {
+                match event {
+                    Closed => *quit = true,
+                    KeyboardInput { input, .. } => {
+                        use glium::glutin::VirtualKeyCode as Key;
+
+                        let pressed = input.state == Pressed;
+                        match input.virtual_keycode {
+                            Some(Key::Tab) => imgui.set_key(0, pressed),
+                            Some(Key::Left) => imgui.set_key(1, pressed),
+                            Some(Key::Right) => imgui.set_key(2, pressed),
+                            Some(Key::Up) => imgui.set_key(3, pressed),
+                            Some(Key::Down) => imgui.set_key(4, pressed),
+                            Some(Key::PageUp) => imgui.set_key(5, pressed),
+                            Some(Key::PageDown) => imgui.set_key(6, pressed),
+                            Some(Key::Home) => imgui.set_key(7, pressed),
+                            Some(Key::End) => imgui.set_key(8, pressed),
+                            Some(Key::Delete) => imgui.set_key(9, pressed),
+                            Some(Key::Back) => imgui.set_key(10, pressed),
+                            Some(Key::Return) => imgui.set_key(11, pressed),
+                            Some(Key::Escape) => imgui.set_key(12, pressed),
+                            Some(Key::A) => imgui.set_key(13, pressed),
+                            Some(Key::C) => imgui.set_key(14, pressed),
+                            Some(Key::V) => imgui.set_key(15, pressed),
+                            Some(Key::X) => imgui.set_key(16, pressed),
+                            Some(Key::Y) => imgui.set_key(17, pressed),
+                            Some(Key::Z) => imgui.set_key(18, pressed),
+                            Some(Key::LControl) | Some(Key::RControl) => {
+                                imgui.set_key_ctrl(pressed)
+                            }
+                            Some(Key::LShift) | Some(Key::RShift) => imgui.set_key_shift(pressed),
+                            Some(Key::LAlt) | Some(Key::RAlt) => imgui.set_key_alt(pressed),
+                            Some(Key::LWin) | Some(Key::RWin) => imgui.set_key_super(pressed),
+                            _ => {}
+                        }
+                    }
+                    CursorMoved {
+                        position: (x, y), ..
+                    } => mouse_state.pos = (x as i32, y as i32),
+                    MouseInput { state, button, .. } => match button {
+                        MouseButton::Left => mouse_state.pressed.0 = state == Pressed,
+                        MouseButton::Right => mouse_state.pressed.1 = state == Pressed,
+                        MouseButton::Middle => mouse_state.pressed.2 = state == Pressed,
+                        _ => {}
+                    },
+                    MouseWheel {
+                        delta: MouseScrollDelta::LineDelta(_, y),
+                        phase: TouchPhase::Moved,
+                        ..
+                    }
+                    | MouseWheel {
+                        delta: MouseScrollDelta::PixelDelta(_, y),
+                        phase: TouchPhase::Moved,
+                        ..
+                    } => mouse_state.wheel = y,
+                    ReceivedCharacter(c) => imgui.add_input_character(c),
+                    _ => (),
+                }
+            }
+        });
+    }
+
+    pub fn imgui(&self) -> &ImGui { &self.imgui }
+
+    pub fn imgui_mut(&mut self) -> &mut ImGui { &mut self.imgui }
+}
+
+fn configure_keys(imgui: &mut ImGui) {
+    use imgui::ImGuiKey;
+
+    imgui.set_imgui_key(ImGuiKey::Tab, 0);
+    imgui.set_imgui_key(ImGuiKey::LeftArrow, 1);
+    imgui.set_imgui_key(ImGuiKey::RightArrow, 2);
+    imgui.set_imgui_key(ImGuiKey::UpArrow, 3);
+    imgui.set_imgui_key(ImGuiKey::DownArrow, 4);
+    imgui.set_imgui_key(ImGuiKey::PageUp, 5);
+    imgui.set_imgui_key(ImGuiKey::PageDown, 6);
+    imgui.set_imgui_key(ImGuiKey::Home, 7);
+    imgui.set_imgui_key(ImGuiKey::End, 8);
+    imgui.set_imgui_key(ImGuiKey::Delete, 9);
+    imgui.set_imgui_key(ImGuiKey::Backspace, 10);
+    imgui.set_imgui_key(ImGuiKey::Enter, 11);
+    imgui.set_imgui_key(ImGuiKey::Escape, 12);
+    imgui.set_imgui_key(ImGuiKey::A, 13);
+    imgui.set_imgui_key(ImGuiKey::C, 14);
+    imgui.set_imgui_key(ImGuiKey::V, 15);
+    imgui.set_imgui_key(ImGuiKey::X, 16);
+    imgui.set_imgui_key(ImGuiKey::Y, 17);
+    imgui.set_imgui_key(ImGuiKey::Z, 18);
+}
+
+fn update_mouse(imgui: &mut ImGui, mouse_state: &mut MouseState) {
+    let scale = imgui.display_framebuffer_scale();
+    imgui.set_mouse_pos(
+        mouse_state.pos.0 as f32 / scale.0,
+        mouse_state.pos.1 as f32 / scale.1,
+    );
+    imgui.set_mouse_down(&[
+        mouse_state.pressed.0,
+        mouse_state.pressed.1,
+        mouse_state.pressed.2,
+        false,
+        false,
+    ]);
+    imgui.set_mouse_wheel(mouse_state.wheel / scale.1);
+    mouse_state.wheel = 0.0;
+}
+
+fn update_os_cursor(imgui: &ImGui, gl_window: &Ref<glutin::GlWindow>) {
+    let mouse_cursor = imgui.mouse_cursor();
+    if imgui.mouse_draw_cursor() || mouse_cursor == ImGuiMouseCursor::None {
+        // Hide OS cursor
+        gl_window
+            .set_cursor_state(glutin::CursorState::Hide)
+            .unwrap();
+    } else {
+        // Set OS cursor
+        gl_window
+            .set_cursor_state(glutin::CursorState::Normal)
+            .unwrap();
+        gl_window.set_cursor(match mouse_cursor {
+            ImGuiMouseCursor::None => unreachable!("mouse_cursor was None!"),
+            ImGuiMouseCursor::Arrow => glutin::MouseCursor::Arrow,
+            ImGuiMouseCursor::TextInput => glutin::MouseCursor::Text,
+            ImGuiMouseCursor::Move => glutin::MouseCursor::Move,
+            ImGuiMouseCursor::ResizeNS => glutin::MouseCursor::NsResize,
+            ImGuiMouseCursor::ResizeEW => glutin::MouseCursor::EwResize,
+            ImGuiMouseCursor::ResizeNESW => glutin::MouseCursor::NeswResize,
+            ImGuiMouseCursor::ResizeNWSE => glutin::MouseCursor::NwseResize,
+        });
+    }
+}

--- a/imgui-glium-renderer/src/im_texture.rs
+++ b/imgui-glium-renderer/src/im_texture.rs
@@ -1,0 +1,31 @@
+use std::mem;
+use std::ops::Deref;
+
+use glium::Texture2d;
+use imgui::{FromImTexture, ImTexture, ImTextureID, IntoImTexture};
+
+/// Handle to a glium texture
+///
+/// Implements [`Deref`] to get direct access to the underlying [`Texture2d`]
+/// object.
+pub struct Texture(Texture2d);
+
+impl ImTexture for Texture {
+    fn get_id(&self) -> ImTextureID { unsafe { mem::transmute(self) } }
+    fn get_size(&self) -> (u32, u32) { self.0.dimensions() }
+}
+
+impl IntoImTexture<Texture> for Texture2d {
+    fn into_texture(self) -> Texture { Texture(self) }
+}
+
+impl Deref for Texture {
+    type Target = Texture2d;
+    fn deref(&self) -> &Self::Target { &self.0 }
+}
+
+impl FromImTexture for Texture {
+    fn from_id<'a>(texture_id: ImTextureID) -> &'a Self {
+        unsafe { mem::transmute::<_, &Texture>(texture_id) }
+    }
+}

--- a/imgui-glium-renderer/src/lib.rs
+++ b/imgui-glium-renderer/src/lib.rs
@@ -5,7 +5,7 @@ extern crate imgui;
 mod im_texture;
 pub use im_texture::Texture;
 
-use glium::{DrawError, GlObject, IndexBuffer, Program, Surface, Texture2d, VertexBuffer};
+use glium::{DrawError, IndexBuffer, Program, Surface, Texture2d, VertexBuffer};
 use glium::backend::{Context, Facade};
 use glium::program;
 use glium::index::{self, PrimitiveType};
@@ -14,7 +14,6 @@ use glium::vertex;
 use imgui::{DrawList, FromImTexture, ImDrawIdx, ImDrawVert, ImGui, Ui};
 use std::borrow::Cow;
 use std::fmt;
-use std::ops::Deref;
 use std::rc::Rc;
 
 pub type RendererResult<T> = Result<T, RendererError>;
@@ -115,17 +114,12 @@ impl Renderer {
             [0.0, 0.0, -1.0, 0.0],
             [-1.0, 1.0, 0.0, 1.0],
         ];
-        let font_texture_id = self.device_objects.texture.get_id() as usize;
 
         let mut idx_start = 0;
         for cmd in draw_list.cmd_buffer {
             let idx_end = idx_start + cmd.elem_count as usize;
 
-            let texture = if cmd.texture_id as usize == font_texture_id {
-                &self.device_objects.texture
-            } else {
-                <Texture as FromImTexture>::from_id(cmd.texture_id).deref()
-            };
+            let texture = <Texture as FromImTexture>::from_id(cmd.texture_id);
 
             try!(
                 surface.draw(
@@ -165,7 +159,6 @@ pub struct DeviceObjects {
     vertex_buffer: VertexBuffer<ImDrawVert>,
     index_buffer: IndexBuffer<ImDrawIdx>,
     program: Program,
-    texture: Texture2d,
 }
 
 fn compile_default_program<F: Facade>(
@@ -213,7 +206,7 @@ impl DeviceObjects {
         ));
 
         let program = try!(compile_default_program(ctx));
-        let texture = try!(im_gui.prepare_texture(|handle| {
+        let texture = try!(im_gui.register_font_texture(|handle| {
             let data = RawImage2d {
                 data: Cow::Borrowed(handle.pixels),
                 width: handle.width,
@@ -222,13 +215,13 @@ impl DeviceObjects {
             };
             Texture2d::new(ctx, data)
         }));
+
         im_gui.set_texture_id(texture.get_id() as usize);
 
         Ok(DeviceObjects {
             vertex_buffer: vertex_buffer,
             index_buffer: index_buffer,
             program: program,
-            texture: texture,
         })
     }
     pub fn upload_vertex_buffer<F: Facade>(

--- a/imgui-glium-renderer/src/lib.rs
+++ b/imgui-glium-renderer/src/lib.rs
@@ -2,6 +2,9 @@
 extern crate glium;
 extern crate imgui;
 
+mod im_texture;
+pub use im_texture::Texture;
+
 use glium::{DrawError, GlObject, IndexBuffer, Program, Surface, Texture2d, VertexBuffer};
 use glium::backend::{Context, Facade};
 use glium::program;

--- a/imgui-sys/src/lib.rs
+++ b/imgui-sys/src/lib.rs
@@ -818,8 +818,8 @@ pub struct ImFontAtlas {
 
     tex_pixels_alpha8: *mut c_uchar,
     tex_pixels_rgba32: *mut c_uint,
-    tex_width: c_int,
-    tex_height: c_int,
+    pub tex_width: c_int,
+    pub tex_height: c_int,
     tex_uv_white_pixel: ImVec2,
     fonts: ImVector<*mut ImFont>,
     custom_rects: ImVector<CustomRect>,

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -4,6 +4,9 @@ use std::os::raw::{c_int, c_void};
 use std::ptr;
 use sys;
 
+use super::ImTexture;
+use sys::ImTextureID;
+
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 enum FontGlyphRangeData {
     Chinese, Cyrillic, Default, Japanese, Korean, Thai, Custom(*const sys::ImWchar),
@@ -306,5 +309,19 @@ impl <'a> ImFontAtlas<'a> {
     }
     pub fn set_texture_id(&mut self, value: usize) {
         unsafe { (*self.atlas).tex_id = value as *mut c_void; }
+    }
+}
+
+/// To use font texture
+impl<'a> ImTexture for ImFontAtlas<'a> {
+    fn get_id(&self) -> ImTextureID {
+        self.texture_id() as ImTextureID
+    }
+
+    fn get_size(&self) -> (u32, u32) {
+        unsafe {
+            let atlas = &*self.atlas;
+            (atlas.tex_width as u32, atlas.tex_height as u32)
+        }
     }
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,0 +1,76 @@
+use super::{ImTexture, ImTextureID, ImVec2, ImVec4};
+
+use sys;
+
+pub struct Image {
+    texture_id: ImTextureID,
+    size: ImVec2,
+    uv0: ImVec2,
+    uv1: ImVec2,
+    tint_col: ImVec4,
+    border_col: ImVec4,
+}
+
+impl Image {
+    pub fn new<T, S>(texture: &T, size: S) -> Image
+    where
+        T: ImTexture,
+        S: Into<ImVec2>,
+    {
+        const DEFAULT_UV0: ImVec2 = ImVec2 { x: 0.0, y: 0.0 };
+        const DEFAULT_UV1: ImVec2 = ImVec2 { x: 1.0, y: 1.0 };
+        const DEFAULT_TINT_COL: ImVec4 = ImVec4 {
+            x: 1.0,
+            y: 1.0,
+            z: 1.0,
+            w: 1.0,
+        };
+        const DEFAULT_BORDER_COL: ImVec4 = ImVec4 {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+            w: 0.0,
+        };
+        Image {
+            texture_id: texture.get_id(),
+            size: size.into(),
+            uv0: DEFAULT_UV0,
+            uv1: DEFAULT_UV1,
+            tint_col: DEFAULT_TINT_COL,
+            border_col: DEFAULT_BORDER_COL,
+        }
+    }
+
+    pub fn uv0<T: Into<ImVec2>>(mut self, uv0: T) -> Self {
+        self.uv0 = uv0.into();
+        self
+    }
+
+    pub fn uv1<T: Into<ImVec2>>(mut self, uv1: T) -> Self {
+        self.uv1 = uv1.into();
+        self
+    }
+
+    pub fn tint_col<T: Into<ImVec4>>(mut self, tint_col: T) -> Self {
+        self.tint_col = tint_col.into();
+        self
+    }
+
+    pub fn border_col<T: Into<ImVec4>>(mut self, border_col: T) -> Self {
+        self.border_col = border_col.into();
+        self
+    }
+
+    pub fn build(self) {
+        unsafe {
+            sys::igImage(
+                self.texture_id,
+                self.size,
+                self.uv0,
+                self.uv1,
+                self.tint_col,
+                self.border_col,
+            );
+        }
+    }
+}

--- a/src/image.rs
+++ b/src/image.rs
@@ -2,6 +2,10 @@ use super::{ImTexture, ImTextureID, ImVec2, ImVec4};
 
 use sys;
 
+/// Represent an image about to be drawn
+/// See [`Ui::image`].
+///
+/// Crate your image using the builder pattern then [`Image::build`] it.
 pub struct Image {
     texture_id: ImTextureID,
     size: ImVec2,
@@ -41,26 +45,31 @@ impl Image {
         }
     }
 
+    /// Set uv0 (default `[0.0, 0.0]`)
     pub fn uv0<T: Into<ImVec2>>(mut self, uv0: T) -> Self {
         self.uv0 = uv0.into();
         self
     }
 
+    /// Set uv1 (default `[1.0, 1.0]`)
     pub fn uv1<T: Into<ImVec2>>(mut self, uv1: T) -> Self {
         self.uv1 = uv1.into();
         self
     }
 
+    /// Set tint color (default: no tint color)
     pub fn tint_col<T: Into<ImVec4>>(mut self, tint_col: T) -> Self {
         self.tint_col = tint_col.into();
         self
     }
 
+    /// Set border color (default: no border)
     pub fn border_col<T: Into<ImVec4>>(mut self, border_col: T) -> Self {
         self.border_col = border_col.into();
         self
     }
 
+    /// Draw image where the cursor currently is
     pub fn build(self) {
         unsafe {
             sys::igImage(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1157,6 +1157,33 @@ impl<'ui> Ui<'ui> {
 
 /// Widgets: Images
 impl<'ui> Ui<'ui> {
+    /// Initiate the drawing of an image.
+    /// The image data should be an object implementing the [`ImTexture`] trait,
+    /// typically an [`AnyTexture`] object got from [`Ui::make_texture`].
+    ///
+    /// # Examples
+    ///
+    /// ## Example using glium as back-end
+    ///
+    /// ```rust,no_run
+    /// #[macro_use] extern crate imgui;
+    /// extern crate glium;
+    /// extern crate imgui_glium_renderer;
+    ///
+    /// use imgui::*;
+    /// use glium::Texture2d;
+    /// use glium::backend::Facade;
+    ///
+    /// fn make_a_texture<F: Facade>(ui: &Ui, facade: &F, data: Vec<Vec<(u8, u8, u8, u8)>>) {
+    ///     let texture_handle = ui.replace_texture(
+    ///         im_str!("#Texture Name ID"),
+    ///         Texture2d::new(facade, data).unwrap(),
+    ///     );
+    ///     ui.image(&texture_handle, [100.0, 100.0]).build();
+    /// }
+    ///
+    /// # fn main() {}
+    /// ```
     pub fn image<T, S>(&self, texture: &T, size: S) -> Image
     where
         T: ImTexture,
@@ -1380,6 +1407,34 @@ impl<'ui> Ui<'ui> {
 
 /// # Custom textures
 impl<'ui> Ui<'ui> {
+    /// Register a texture into ImGui the first time the function is called.
+    /// Just reuse the texture on subsequent uses.
+    ///
+    /// Returns a handle to the texture as an [`AnyTexture`] object. A back-end
+    /// (e.g. glium) is needed to create the texture.
+    ///
+    /// # Examples
+    ///
+    /// ## Example using glium as back-end
+    ///
+    /// ```rust,no_run
+    /// #[macro_use] extern crate imgui;
+    /// extern crate glium;
+    /// extern crate imgui_glium_renderer;
+    ///
+    /// use imgui::*;
+    /// use glium::Texture2d;
+    /// use glium::backend::Facade;
+    ///
+    /// fn make_a_texture<F: Facade>(ui: &Ui, facade: &F) {
+    ///     let texture_handle = ui.make_texture(im_str!("#Texture Name ID"), || {
+    ///         Texture2d::empty(facade, 100, 100).unwrap()
+    ///     });
+    ///     // ... Do something with `texture_handle`
+    /// }
+    ///
+    /// # fn main() {}
+    /// ```
     pub fn make_texture<F, T, U>(&self, name: &ImStr, f: F) -> AnyTexture
     where
         F: FnOnce() -> T,
@@ -1396,6 +1451,35 @@ impl<'ui> Ui<'ui> {
         }
     }
 
+    /// Swap and replace with the given new texture each time the function is
+    /// called.
+    ///
+    /// Returns a handle to the texture as an [`AnyTexture`] object. A back-end
+    /// (e.g. glium) is needed to create the texture.
+    ///
+    /// # Examples
+    ///
+    /// ## Example using glium as back-end
+    ///
+    /// ```rust,no_run
+    /// #[macro_use] extern crate imgui;
+    /// extern crate glium;
+    /// extern crate imgui_glium_renderer;
+    ///
+    /// use imgui::*;
+    /// use glium::Texture2d;
+    /// use glium::backend::Facade;
+    ///
+    /// fn make_a_texture<F: Facade>(ui: &Ui, facade: &F, data: Vec<Vec<(u8, u8, u8, u8)>>) {
+    ///     let texture_handle = ui.replace_texture(
+    ///         im_str!("#Texture Name ID"),
+    ///         Texture2d::new(facade, data).unwrap(),
+    ///     );
+    ///     // ... Do something with `texture_handle`
+    /// }
+    ///
+    /// # fn main() {}
+    /// ```
     pub fn replace_texture<T, U>(&self, name: &ImStr, t: T) -> AnyTexture
     where
         T: IntoImTexture<U>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub use color_editors::{ColorButton, ColorEdit, ColorEditMode, ColorFormat, Colo
 pub use drag::{DragFloat, DragFloat2, DragFloat3, DragFloat4, DragInt, DragInt2, DragInt3,
                DragInt4, DragFloatRange2, DragIntRange2};
 pub use fonts::{FontGlyphRange, ImFontAtlas, ImFont, ImFontConfig};
+pub use image::Image;
 pub use input::{InputFloat, InputFloat2, InputFloat3, InputFloat4, InputInt, InputInt2, InputInt3,
                 InputInt4, InputText};
 pub use menus::{Menu, MenuItem};
@@ -37,6 +38,7 @@ mod child_frame;
 mod color_editors;
 mod drag;
 mod fonts;
+mod image;
 mod input;
 mod menus;
 mod plothistogram;
@@ -1150,6 +1152,17 @@ impl<'ui> Ui<'ui> {
         size: S,
     ) -> ChildFrame<'ui, 'p> {
         ChildFrame::new(self, name, size.into())
+    }
+}
+
+/// Widgets: Images
+impl<'ui> Ui<'ui> {
+    pub fn image<T, S>(&self, texture: &T, size: S) -> Image
+    where
+        T: ImTexture,
+        S: Into<ImVec2>,
+    {
+        Image::new(texture, size)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ macro_rules! im_str {
     })
 }
 
-pub struct TextureHandle<'a> {
+pub struct FontTextureHandle<'a> {
     pub width: u32,
     pub height: u32,
     pub pixels: &'a [c_uchar],
@@ -120,7 +120,7 @@ impl ImGui {
     pub fn fonts(&mut self) -> ImFontAtlas { unsafe { ImFontAtlas::from_ptr(self.io_mut().fonts) } }
     pub fn prepare_texture<'a, F, T>(&mut self, f: F) -> T
     where
-        F: FnOnce(TextureHandle<'a>) -> T,
+        F: FnOnce(FontTextureHandle<'a>) -> T,
     {
         let io = self.io();
         let mut pixels: *mut c_uchar = ptr::null_mut();
@@ -135,7 +135,7 @@ impl ImGui {
                 &mut height,
                 &mut bytes_per_pixel,
             );
-            f(TextureHandle {
+            f(FontTextureHandle {
                 width: width as u32,
                 height: height as u32,
                 pixels: slice::from_raw_parts(pixels, (width * height * bytes_per_pixel) as usize),

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -16,6 +16,15 @@ pub trait ImTexture {
     fn get_size(&self) -> (u32, u32);
 }
 
+/// We implement [`ImTexture`] for [`ImTextureID`] one only to be able to use
+/// it on the ID of the font texture (as is).
+impl ImTexture for ImTextureID {
+    fn get_id(&self) -> ImTextureID { *self }
+    fn get_size(&self) -> (u32, u32) {
+        panic!("Cannot get size of ImTextureID (it is a raw pointer)!")
+    }
+}
+
 /// A handle to a texture.
 ///
 /// Wraps a fat pointer to an trait object [`ImTexture`].

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -1,0 +1,100 @@
+use std::cell::RefCell;
+use std::collections::hash_map::DefaultHasher;
+use std::collections::BTreeMap;
+use std::hash::Hasher;
+use std::ops::Deref;
+use std::rc::Rc;
+
+use super::{ImStr, ImTextureID};
+
+/// Trait that an object representing a texture usable by the drawing back-end
+/// should implement.
+pub trait ImTexture {
+    /// Get [`ImTextureID`]
+    fn get_id(&self) -> ImTextureID;
+    /// Query texture size, in pixels (for convenience)
+    fn get_size(&self) -> (u32, u32);
+}
+
+/// A handle to a texture.
+///
+/// Wraps a fat pointer to an trait object [`ImTexture`].
+//
+//  `Rc` is necessary to make `Box<ImTexture>` clonable.
+//  We need to clone it to extract its value from a `TextureCache`, an type
+//  internal to imgui-rs, which internally contains a `RefCell`.
+#[derive(Clone)]
+pub struct AnyTexture(Rc<Box<ImTexture>>);
+
+impl AnyTexture {
+    /// Create a new [`AnyTexture`] from an object implementing the [`ImTexture`] trait.
+    fn new<T: 'static + ImTexture>(texture: T) -> Self { AnyTexture(Rc::new(Box::new(texture))) }
+}
+
+impl ImTexture for AnyTexture {
+    fn get_id(&self) -> ImTextureID { self.deref().get_id() }
+    fn get_size(&self) -> (u32, u32) { self.deref().get_size() }
+}
+
+/// Allows to directly use the methods implemnted on [`AnyTexture`]
+impl Deref for AnyTexture {
+    type Target = Box<ImTexture>;
+
+    fn deref(&self) -> &Self::Target { Deref::deref(&self.0) }
+}
+
+/// Trait defining how an external type can be converted into a type implementing
+/// [`ImTexture`].
+///
+/// Typically implemented to convert a native type (e.g. Texture2d from the
+/// glium crate) to a type defined in the back-end implemnting [`ImTexture`].
+pub trait IntoImTexture<T>
+where
+    T: ImTexture,
+{
+    fn into_texture(self) -> T;
+}
+
+/// Trait defining how an object implementing [`ImTexture`] should be converted
+/// back to the native texture type used by the back-end.
+pub trait FromImTexture {
+    fn from_im_texture<T: ImTexture>(texture: &T) -> &Self {
+        let texture = texture.get_id();
+        Self::from_id(texture)
+    }
+    fn from_id<'a>(texture_id: ImTextureID) -> &'a Self;
+}
+
+/// Owns all the custom textures used by ImGui.
+///
+/// Use interior mutability to register or delete textures.
+pub struct TextureCache(RefCell<BTreeMap<u64, AnyTexture>>);
+
+impl TextureCache {
+    pub fn new() -> Self { TextureCache(RefCell::new(BTreeMap::new())) }
+
+    /// Register the texture inside the cache.
+    ///
+    /// Swap and return some texture if another texture with the same name was
+    /// already registered.
+    pub fn register_texture<T>(&self, name: &ImStr, texture: T) -> Option<AnyTexture>
+    where
+        T: 'static + ImTexture,
+    {
+        let id = hash_imstring(name);
+        self.0.borrow_mut().insert(id, AnyTexture::new(texture))
+    }
+
+    /// Get the texture in the cache with the given name, if it exists.
+    pub fn get_texture(&self, name: &ImStr) -> Option<AnyTexture> {
+        let id = hash_imstring(name);
+        self.0.borrow().get(&id).map(Clone::clone)
+    }
+}
+
+/// Used to compute the ID of a texture
+fn hash_imstring(string: &ImStr) -> u64 {
+    let mut h = DefaultHasher::new();
+    h.write(string.to_str().as_bytes());
+    h.finish()
+}


### PR DESCRIPTION
Fixes #65.

Implement custom texture support. Each commit message thoroughly explain the content of the commit.

Before merging, I want to know the maintainer(s) opinion about the design choices of this PR.
It is designed with memory safety and back-end agnosticity in mind.
Suggestions and improvements are welcome.

Shortcomings of the design choices are explained in the very first commit of the PR: 3013e03.
Please see the new example to get an idea how the custom texture API is used.

- Some rework on the `support` module of the example is necessary, as creating custom textures in `glium` requires access to the gl context. In this PR, I created a `support_custom_textures` module that allows to get the gl context (c58eb9c). I would like to include this `support_custom_textures` module and its AppContext/AppConfig types into `imgui_glium_renderer` and rewrite all the examples. Any objection?
- I would like to add safe wrappers to `igImageButton` and `ImDrawList_AddImage` once the design is validated. 
- My current knowledge of `gfx` is abysmal. I need to study a bit more `gfx` before I can write the part of the gfx backend for custom texture support. Moreover, it seems that the `gfx` crate is about to be deprecated as `gfx` is currently being rewritten from scratch [1], so I would rather directly implement a back-end using the master branch of `gfx` as base. What do you think we should do? Can we merge with gfx support first?

[1] https://github.com/gfx-rs/gfx/#pre-ll

EDIT: Font textutre is no longer treated as a separate case in 1de593a 