### PR TITLE
Add want_capture_mouse and want_capture_keyboard to ImGui (fixes #128)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,6 +314,8 @@ impl ImGui {
     pub fn get_time(&self) -> f32 { unsafe { sys::igGetTime() } }
     pub fn get_frame_count(&self) -> i32 { unsafe { sys::igGetFrameCount() } }
     pub fn get_frame_rate(&self) -> f32 { self.io().framerate }
+    pub fn want_capture_mouse(&self) -> bool { self.io().want_capture_mouse }
+    pub fn want_capture_keyboard(&self) -> bool { self.io().want_capture_keyboard }
     pub fn frame<'ui, 'a: 'ui>(
         &'a mut self,
         size_points: (u32, u32),
@@ -372,12 +374,10 @@ fn fmt_ptr() -> *const c_char { FMT.as_ptr() as *const c_char }
 impl<'ui> Ui<'ui> {
     pub fn imgui(&self) -> &ImGui { self.imgui }
     pub fn want_capture_mouse(&self) -> bool {
-        let io = self.imgui.io();
-        io.want_capture_mouse
+        self.imgui().want_capture_mouse()
     }
     pub fn want_capture_keyboard(&self) -> bool {
-        let io = self.imgui.io();
-        io.want_capture_keyboard
+        self.imgui().want_capture_keyboard()
     }
     pub fn framerate(&self) -> f32 {
         let io = self.imgui.io();


### PR DESCRIPTION
These should be on the ImGui object so that you can update state separately from drawing the Ui (there are also lifetime annoyances that are made much worse by them only being on Ui).

I left the versions on Ui (both for backwards compatibility and because I don't see why they shouldn't be there), but they just call the versions on ImGui now.