### PR TITLE
[examples] support: Fix scale bug

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -41,6 +41,9 @@
   Keep redirection.
   - Rename `ImGuiCol::ChildWindowBg` to `ImGuiCol::ChildBg`.
   Keep redirection.
+- Upgrade glium to 0.22.0. This updates winit to 0.16. This changes the way
+HIDPI are calculated. Depending on your needs, you may want to set HIDPI to 1
+by setting the environment variable `WINIT_HIDPI_FACTOR=1` if you use X11.
 
 ### Deprecated
 

--- a/imgui-examples/examples/support/mod.rs
+++ b/imgui-examples/examples/support/mod.rs
@@ -129,14 +129,11 @@ pub fn run<F: FnMut(&Ui) -> bool>(title: String, clear_color: [f32; 4], mut run_
             });
         }
 
-        let size_pixels = gl_window.get_inner_size().unwrap();
+        let size_points = gl_window.get_inner_size().unwrap();
         let hdipi = gl_window.get_hidpi_factor();
-        let size_points = (
-            (size_pixels.width as f64 / hdipi) as u32,
-            (size_pixels.height as f64 / hdipi) as u32,
-        );
+        let size_pixels = size_points.to_physical(hdipi);
 
-        let ui = imgui.frame(size_points, size_pixels.into(), delta_s);
+        let ui = imgui.frame(size_points.into(), size_pixels.into(), delta_s);
         if !run_ui(&ui) {
             break;
         }
@@ -182,11 +179,7 @@ fn configure_keys(imgui: &mut ImGui) {
 }
 
 fn update_mouse(imgui: &mut ImGui, mouse_state: &mut MouseState) {
-    let scale = imgui.display_framebuffer_scale();
-    imgui.set_mouse_pos(
-        mouse_state.pos.0 as f32 / scale.0,
-        mouse_state.pos.1 as f32 / scale.1,
-    );
+    imgui.set_mouse_pos(mouse_state.pos.0 as f32, mouse_state.pos.1 as f32);
     imgui.set_mouse_down(
         &[
             mouse_state.pressed.0,
@@ -196,6 +189,6 @@ fn update_mouse(imgui: &mut ImGui, mouse_state: &mut MouseState) {
             false,
         ],
     );
-    imgui.set_mouse_wheel(mouse_state.wheel / scale.1);
+    imgui.set_mouse_wheel(mouse_state.wheel);
     mouse_state.wheel = 0.0;
 }

--- a/imgui-examples/examples/support_gfx/mod.rs
+++ b/imgui-examples/examples/support_gfx/mod.rs
@@ -174,14 +174,11 @@ pub fn run<F: FnMut(&Ui) -> bool>(title: String, clear_color: [f32; 4], mut run_
             });
         }
 
-        let size_pixels = window.get_inner_size().unwrap();
+        let size_points = window.get_inner_size().unwrap();
         let hdipi = window.get_hidpi_factor();
-        let size_points = (
-            (size_pixels.width as f64 / hdipi) as u32,
-            (size_pixels.height as f64 / hdipi) as u32,
-        );
+        let size_pixels = size_points.to_physical(hdipi);
 
-        let ui = imgui.frame(size_points, size_pixels.into(), delta_s);
+        let ui = imgui.frame(size_points.into(), size_pixels.into(), delta_s);
         if !run_ui(&ui) {
             break;
         }
@@ -221,11 +218,7 @@ fn configure_keys(imgui: &mut ImGui) {
 }
 
 fn update_mouse(imgui: &mut ImGui, mouse_state: &mut MouseState) {
-    let scale = imgui.display_framebuffer_scale();
-    imgui.set_mouse_pos(
-        mouse_state.pos.0 as f32 / scale.0,
-        mouse_state.pos.1 as f32 / scale.1,
-    );
+    imgui.set_mouse_pos(mouse_state.pos.0 as f32, mouse_state.pos.1 as f32);
     imgui.set_mouse_down(
         &[
             mouse_state.pressed.0,
@@ -235,6 +228,6 @@ fn update_mouse(imgui: &mut ImGui, mouse_state: &mut MouseState) {
             false,
         ],
     );
-    imgui.set_mouse_wheel(mouse_state.wheel / scale.1);
+    imgui.set_mouse_wheel(mouse_state.wheel);
     mouse_state.wheel = 0.0;
 }


### PR DESCRIPTION
The new version of glutin apparently changed the behaviour regarding
HDIPI.
This PR is partly inspired from the patch submitted by @semtexzv #139.

However, the scaling issue is not completely fixed yet, everything appears way enlarged on my system.
(below is a screenshot taken from a 3200-pixel-wide screen)

![image](https://user-images.githubusercontent.com/14120117/43958969-19d6ef7e-9ce8-11e8-809e-19fe2598a41b.png)

I want the examples in imgui-rs to have the same behaviour as before. @Gekkio  Any thought?

EDIT: After reading glutin's documentation [about dpi](https://docs.rs/glutin/0.18.0/glutin/dpi/index.html), I was able to get the behaviour we had before updating glutin by setting the environment variable WINIT_HIDPI_FACTOR to 1 (my system uses x11).

```sh
WINIT_HIDPI_FACTOR=1 cargo run --example test_window_impl
```

I am not sure what should be the correct thing to do for imgui-rs...