### PR TITLE
Alternate Implementation of custom texture support for glium back-end

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ travis-ci = { repository = "Gekkio/imgui-rs" }
 imgui-sys = { version = "0.0.21-pre", path = "imgui-sys" }
 
 [workspace]
-members = ["imgui-examples", "imgui-sys", "imgui-gfx-renderer", "imgui-glium-renderer", "imgui-glutin-support"]
+members = ["imgui-examples", "imgui-sys", "imgui-gfx-renderer", "imgui-glium-renderer", "imgui-glium-textured-renderer", "imgui-glutin-support"]

--- a/imgui-examples/Cargo.toml
+++ b/imgui-examples/Cargo.toml
@@ -16,3 +16,4 @@ glutin = "0.18"
 imgui = { version = "0.0.21-pre", path = "../" }
 imgui-gfx-renderer = { version = "0.0.21-pre", path = "../imgui-gfx-renderer" }
 imgui-glium-renderer = { version = "0.0.21-pre", path = "../imgui-glium-renderer" }
+imgui-glium-textured-renderer = { version = "0.0.21-pre", path = "../imgui-glium-textured-renderer" }

--- a/imgui-examples/examples/custom_textures.rs
+++ b/imgui-examples/examples/custom_textures.rs
@@ -1,0 +1,93 @@
+#[macro_use]
+extern crate glium;
+#[macro_use]
+extern crate imgui;
+extern crate imgui_glium_textured_renderer;
+
+use glium::backend::Context;
+use glium::Texture2d;
+use imgui::*;
+use std::rc::Rc;
+mod support_texture;
+
+const CLEAR_COLOR: [f32; 4] = [1.0, 1.0, 1.0, 1.0];
+
+fn main() {
+    let mut init = false;
+    let mut t = 0.0;
+
+    support_texture::run("hello_world.rs".to_owned(), CLEAR_COLOR, |ui, gl_ctx| {
+        if !init {
+            let mut image_data: Vec<Vec<(f32, f32, f32, f32)>> = Vec::new();
+            for i in 0..100 {
+                let mut row: Vec<(f32, f32, f32, f32)> = Vec::new();
+                for j in 0..100 {
+                    row.push((i as f32 / 100.0, j as f32 / 100.0, 0.0, 1.0));
+                }
+                image_data.push(row);
+            }
+            let texture = Texture2d::new(gl_ctx, image_data).unwrap();
+
+            ui.make_texture("#custom".into(), Rc::new(texture));
+            ui.make_texture(
+                "#changing".into(),
+                generate_changing_texture(&mut t, gl_ctx),
+            );
+            init = true;
+        }
+
+        ui.replace_texture(
+            "#changing".into(),
+            generate_changing_texture(&mut t, gl_ctx),
+        ).expect("should be able to replace textures");
+
+        ui.window(im_str!("Hello world"))
+            .size((300.0, 100.0), ImGuiCond::FirstUseEver)
+            .build(|| {
+                ui.text(im_str!("Hello world!"));
+                ui.text(im_str!("こんにちは世界！"));
+                ui.text(im_str!("This...is...imgui-rs!"));
+                ui.separator();
+                let mouse_pos = ui.imgui().mouse_pos();
+                ui.text(im_str!(
+                    "Mouse Position: ({:.1},{:.1})",
+                    mouse_pos.0,
+                    mouse_pos.1
+                ));
+            });
+
+        ui.window(im_str!("Custom Texture"))
+            .size((300.0, 100.0), ImGuiCond::FirstUseEver)
+            .build(|| {
+                ui.image("#custom", (100.0, 100.0)).build();
+            });
+
+        // Changing texture (re-defined and swap texture for each frame)
+        ui.window(im_str!("Changing Texture"))
+            .size((300.0, 100.0), ImGuiCond::FirstUseEver)
+            .build(|| {
+                ui.text(im_str!("Variable texture - {:?}", t));
+                ui.image("#changing", (100.0, 100.0)).build();
+            });
+
+        true
+    });
+}
+
+fn generate_changing_texture(t: &mut f32, gl_ctx: &Rc<Context>) -> Rc<Texture2d> {
+    let mut image_data: Vec<Vec<(f32, f32, f32, f32)>> = Vec::new();
+
+    for i in 0..100 {
+        let mut row: Vec<(f32, f32, f32, f32)> = Vec::new();
+        for j in 0..100 {
+            row.push((i as f32 / 100.0, j as f32 / 100.0, *t, 1.0));
+        }
+        image_data.push(row);
+    }
+
+    *t += 0.01;
+    if *t > 1.0 {
+        *t = 0.0;
+    }
+    Rc::new(Texture2d::new(gl_ctx, image_data).unwrap())
+}

--- a/imgui-examples/examples/support_texture/mod.rs
+++ b/imgui-examples/examples/support_texture/mod.rs
@@ -1,0 +1,241 @@
+use glium::backend::{Context, Facade};
+use glium::Texture2d;
+use imgui::{FontGlyphRange, FrameSize, ImFontConfig, ImGui, ImGuiMouseCursor, TexturedUi, Ui};
+use std::rc::Rc;
+use std::time::Instant;
+
+#[derive(Copy, Clone, PartialEq, Debug, Default)]
+struct MouseState {
+    pos: (i32, i32),
+    pressed: (bool, bool, bool),
+    wheel: f32,
+}
+
+pub fn run<F>(title: String, clear_color: [f32; 4], mut run_ui: F)
+where
+    F: FnMut(&TexturedUi<Rc<::glium::Texture2d>>, &Rc<Context>) -> bool,
+{
+    use glium::glutin;
+    use glium::{Display, Surface};
+    use imgui_glium_textured_renderer::Renderer;
+
+    let mut events_loop = glutin::EventsLoop::new();
+    let context = glutin::ContextBuilder::new().with_vsync(true);
+    let builder = glutin::WindowBuilder::new()
+        .with_title(title)
+        .with_dimensions(glutin::dpi::LogicalSize::new(1024f64, 768f64));
+    let display = Display::new(builder, context, &events_loop).unwrap();
+    let window = display.gl_window();
+
+    let mut imgui = ImGui::init();
+    imgui.set_ini_filename(None);
+
+    // In the examples we only use integer DPI factors, because the UI can get very blurry
+    // otherwise. This might or might not be what you want in a real application.
+    let hidpi_factor = window.get_hidpi_factor().round();
+
+    let font_size = (13.0 * hidpi_factor) as f32;
+
+    imgui.fonts().add_font_with_config(
+        include_bytes!("../mplus-1p-regular.ttf"),
+        ImFontConfig::new()
+            .oversample_h(1)
+            .pixel_snap_h(true)
+            .size_pixels(font_size)
+            .rasterizer_multiply(1.75),
+        &FontGlyphRange::japanese(),
+    );
+
+    imgui.fonts().add_default_font_with_config(
+        ImFontConfig::new()
+            .merge_mode(true)
+            .oversample_h(1)
+            .pixel_snap_h(true)
+            .size_pixels(font_size),
+    );
+
+    imgui.set_font_global_scale((1.0 / hidpi_factor) as f32);
+
+    let mut renderer = Renderer::init(&mut imgui, &display).expect("Failed to initialize renderer");
+
+    configure_keys(&mut imgui);
+
+    let mut last_frame = Instant::now();
+    let mut mouse_state = MouseState::default();
+    let mut quit = false;
+
+    loop {
+        events_loop.poll_events(|event| {
+            use glium::glutin::ElementState::Pressed;
+            use glium::glutin::WindowEvent::*;
+            use glium::glutin::{Event, MouseButton, MouseScrollDelta, TouchPhase};
+
+            if let Event::WindowEvent { event, .. } = event {
+                match event {
+                    CloseRequested => quit = true,
+                    KeyboardInput { input, .. } => {
+                        use glium::glutin::VirtualKeyCode as Key;
+
+                        let pressed = input.state == Pressed;
+                        match input.virtual_keycode {
+                            Some(Key::Tab) => imgui.set_key(0, pressed),
+                            Some(Key::Left) => imgui.set_key(1, pressed),
+                            Some(Key::Right) => imgui.set_key(2, pressed),
+                            Some(Key::Up) => imgui.set_key(3, pressed),
+                            Some(Key::Down) => imgui.set_key(4, pressed),
+                            Some(Key::PageUp) => imgui.set_key(5, pressed),
+                            Some(Key::PageDown) => imgui.set_key(6, pressed),
+                            Some(Key::Home) => imgui.set_key(7, pressed),
+                            Some(Key::End) => imgui.set_key(8, pressed),
+                            Some(Key::Delete) => imgui.set_key(9, pressed),
+                            Some(Key::Back) => imgui.set_key(10, pressed),
+                            Some(Key::Return) => imgui.set_key(11, pressed),
+                            Some(Key::Escape) => imgui.set_key(12, pressed),
+                            Some(Key::A) => imgui.set_key(13, pressed),
+                            Some(Key::C) => imgui.set_key(14, pressed),
+                            Some(Key::V) => imgui.set_key(15, pressed),
+                            Some(Key::X) => imgui.set_key(16, pressed),
+                            Some(Key::Y) => imgui.set_key(17, pressed),
+                            Some(Key::Z) => imgui.set_key(18, pressed),
+                            Some(Key::LControl) | Some(Key::RControl) => {
+                                imgui.set_key_ctrl(pressed)
+                            }
+                            Some(Key::LShift) | Some(Key::RShift) => imgui.set_key_shift(pressed),
+                            Some(Key::LAlt) | Some(Key::RAlt) => imgui.set_key_alt(pressed),
+                            Some(Key::LWin) | Some(Key::RWin) => imgui.set_key_super(pressed),
+                            _ => {}
+                        }
+                    }
+                    CursorMoved { position: pos, .. } => {
+                        // Rescale position from glutin logical coordinates to our logical
+                        // coordinates
+                        mouse_state.pos = pos
+                            .to_physical(window.get_hidpi_factor())
+                            .to_logical(hidpi_factor)
+                            .into();
+                    }
+                    MouseInput { state, button, .. } => match button {
+                        MouseButton::Left => mouse_state.pressed.0 = state == Pressed,
+                        MouseButton::Right => mouse_state.pressed.1 = state == Pressed,
+                        MouseButton::Middle => mouse_state.pressed.2 = state == Pressed,
+                        _ => {}
+                    },
+                    MouseWheel {
+                        delta: MouseScrollDelta::LineDelta(_, y),
+                        phase: TouchPhase::Moved,
+                        ..
+                    } => mouse_state.wheel = y,
+                    MouseWheel {
+                        delta: MouseScrollDelta::PixelDelta(pos),
+                        phase: TouchPhase::Moved,
+                        ..
+                    } => {
+                        // Rescale pixel delta from glutin logical coordinates to our logical
+                        // coordinates
+                        mouse_state.wheel = pos
+                            .to_physical(window.get_hidpi_factor())
+                            .to_logical(hidpi_factor)
+                            .y as f32;
+                    }
+                    ReceivedCharacter(c) => imgui.add_input_character(c),
+                    _ => (),
+                }
+            }
+        });
+
+        let now = Instant::now();
+        let delta = now - last_frame;
+        let delta_s = delta.as_secs() as f32 + delta.subsec_nanos() as f32 / 1_000_000_000.0;
+        last_frame = now;
+
+        update_mouse(&mut imgui, &mut mouse_state);
+
+        let mouse_cursor = imgui.mouse_cursor();
+        if imgui.mouse_draw_cursor() || mouse_cursor == ImGuiMouseCursor::None {
+            // Hide OS cursor
+            window.hide_cursor(true);
+        } else {
+            // Set OS cursor
+            window.hide_cursor(false);
+            window.set_cursor(match mouse_cursor {
+                ImGuiMouseCursor::None => unreachable!("mouse_cursor was None!"),
+                ImGuiMouseCursor::Arrow => glutin::MouseCursor::Arrow,
+                ImGuiMouseCursor::TextInput => glutin::MouseCursor::Text,
+                ImGuiMouseCursor::Move => glutin::MouseCursor::Move,
+                ImGuiMouseCursor::ResizeNS => glutin::MouseCursor::NsResize,
+                ImGuiMouseCursor::ResizeEW => glutin::MouseCursor::EwResize,
+                ImGuiMouseCursor::ResizeNESW => glutin::MouseCursor::NeswResize,
+                ImGuiMouseCursor::ResizeNWSE => glutin::MouseCursor::NwseResize,
+            });
+        }
+
+        // Rescale window size from glutin logical size to our logical size
+        let physical_size = window
+            .get_inner_size()
+            .unwrap()
+            .to_physical(window.get_hidpi_factor());
+        let logical_size = physical_size.to_logical(hidpi_factor);
+
+        let frame_size = FrameSize {
+            logical_size: logical_size.into(),
+            hidpi_factor,
+        };
+
+        let ui = imgui.frame(frame_size, delta_s);
+
+        if !run_ui(&renderer.textured_ui(&ui), display.get_context()) {
+            break;
+        }
+
+        let mut target = display.draw();
+        target.clear_color(
+            clear_color[0],
+            clear_color[1],
+            clear_color[2],
+            clear_color[3],
+        );
+        renderer.render(&mut target, ui).expect("Rendering failed");
+        target.finish().unwrap();
+
+        if quit {
+            break;
+        }
+    }
+}
+
+fn configure_keys(imgui: &mut ImGui) {
+    use imgui::ImGuiKey;
+
+    imgui.set_imgui_key(ImGuiKey::Tab, 0);
+    imgui.set_imgui_key(ImGuiKey::LeftArrow, 1);
+    imgui.set_imgui_key(ImGuiKey::RightArrow, 2);
+    imgui.set_imgui_key(ImGuiKey::UpArrow, 3);
+    imgui.set_imgui_key(ImGuiKey::DownArrow, 4);
+    imgui.set_imgui_key(ImGuiKey::PageUp, 5);
+    imgui.set_imgui_key(ImGuiKey::PageDown, 6);
+    imgui.set_imgui_key(ImGuiKey::Home, 7);
+    imgui.set_imgui_key(ImGuiKey::End, 8);
+    imgui.set_imgui_key(ImGuiKey::Delete, 9);
+    imgui.set_imgui_key(ImGuiKey::Backspace, 10);
+    imgui.set_imgui_key(ImGuiKey::Enter, 11);
+    imgui.set_imgui_key(ImGuiKey::Escape, 12);
+    imgui.set_imgui_key(ImGuiKey::A, 13);
+    imgui.set_imgui_key(ImGuiKey::C, 14);
+    imgui.set_imgui_key(ImGuiKey::V, 15);
+    imgui.set_imgui_key(ImGuiKey::X, 16);
+    imgui.set_imgui_key(ImGuiKey::Y, 17);
+    imgui.set_imgui_key(ImGuiKey::Z, 18);
+}
+
+fn update_mouse(imgui: &mut ImGui, mouse_state: &mut MouseState) {
+    imgui.set_mouse_pos(mouse_state.pos.0 as f32, mouse_state.pos.1 as f32);
+    imgui.set_mouse_down([
+        mouse_state.pressed.0,
+        mouse_state.pressed.1,
+        mouse_state.pressed.2,
+        false,
+        false,
+    ]);
+    imgui.set_mouse_wheel(mouse_state.wheel);
+    mouse_state.wheel = 0.0;
+}

--- a/imgui-gfx-renderer/src/lib.rs
+++ b/imgui-gfx-renderer/src/lib.rs
@@ -120,7 +120,7 @@ impl<R: Resources> Renderer<R> {
             gfx::memory::Usage::Dynamic,
             Bind::empty(),
         )?;
-        let (_, texture) = imgui.prepare_texture(|handle| {
+        let (_, texture) = imgui.prepare_font_texture(|handle| {
             factory.create_texture_immutable_u8::<gfx::format::Rgba8>(
                 gfx::texture::Kind::D2(
                     handle.width as u16,
@@ -215,6 +215,8 @@ impl<R: Resources> Renderer<R> {
         self.bundle.slice.start = 0;
         for cmd in draw_list.cmd_buffer {
             // TODO: check cmd.texture_id
+            // TODOK: here we can change the texture based on
+            // self.bundle.data.texture = imgui.retrieve_texture(cmd.texture_id)?;
 
             self.bundle.slice.end = self.bundle.slice.start + cmd.elem_count;
             self.bundle.data.scissor = Rect {

--- a/imgui-glium-renderer/src/lib.rs
+++ b/imgui-glium-renderer/src/lib.rs
@@ -104,7 +104,7 @@ impl Renderer {
         let result = ui.render(|ui, mut draw_data| {
             draw_data.scale_clip_rects(ui.imgui().display_framebuffer_scale());
             for draw_list in draw_data.into_iter() {
-                self.render_draw_list(surface, &draw_list, fb_size, matrix, ui)?;
+                self.render_draw_list(surface, &draw_list, fb_size, matrix)?;
             }
             Ok(())
         });
@@ -118,7 +118,6 @@ impl Renderer {
         draw_list: &DrawList<'a>,
         fb_size: (f32, f32),
         matrix: [[f32; 4]; 4],
-        ui: &Ui<'a>,
     ) -> RendererResult<()> {
         use glium::{Blend, DrawParameters, Rect};
 
@@ -130,13 +129,11 @@ impl Renderer {
             .upload_index_buffer(&self.ctx, draw_list.idx_buffer)?;
         let texture = &self.device_objects.texture;
 
-        // let texture = self.bundle.data.texture = imgui.retrieve_texture(cmd.texture_id)?;
 
         let font_texture_id = self.device_objects.texture.get_id() as usize;
 
         let mut idx_start = 0;
         for cmd in draw_list.cmd_buffer {
-            // We don't support custom textures...yet!
             assert!(cmd.texture_id as usize == font_texture_id);
 
             let idx_end = idx_start + cmd.elem_count as usize;

--- a/imgui-glium-textured-renderer/Cargo.toml
+++ b/imgui-glium-textured-renderer/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "imgui-glium-textured-renderer"
+version = "0.0.21-pre"
+authors = ["Joonas Javanainen <joonas.javanainen@gmail.com>", "imgui-rs contributors"]
+description = "Glium renderer for the imgui crate with support for custom textures"
+homepage = "https://github.com/Gekkio/imgui-rs"
+repository = "https://github.com/Gekkio/imgui-rs"
+license = "MIT/Apache-2.0"
+categories = ["gui", "rendering"]
+
+[badges]
+travis-ci = { repository = "Gekkio/imgui-rs" }
+
+[dependencies]
+glium = { version = "0.22", default-features = false }
+imgui = { version = "0.0.21-pre", path = "../" }
+imgui-sys = { version = "0.0.21-pre", path = "../imgui-sys", features = ["glium"] }

--- a/imgui-glium-textured-renderer/src/lib.rs
+++ b/imgui-glium-textured-renderer/src/lib.rs
@@ -125,7 +125,7 @@ impl Renderer {
         let result = ui.render(|ui, mut draw_data| {
             draw_data.scale_clip_rects(ui.imgui().display_framebuffer_scale());
             for draw_list in draw_data.into_iter() {
-                self.render_draw_list(surface, &draw_list, fb_size, matrix, ui)?;
+                self.render_draw_list(surface, &draw_list, fb_size, matrix)?;
             }
             Ok(())
         });
@@ -139,7 +139,6 @@ impl Renderer {
         draw_list: &DrawList<'a>,
         fb_size: (f32, f32),
         matrix: [[f32; 4]; 4],
-        ui: &Ui<'a>,
     ) -> RendererResult<()> {
         use glium::{Blend, DrawParameters, Rect};
 
@@ -151,13 +150,12 @@ impl Renderer {
             .upload_index_buffer(&self.ctx, draw_list.idx_buffer)?;
         let texture = &self.device_objects.texture;
 
-        // let texture = self.bundle.data.texture = imgui.retrieve_texture(cmd.texture_id)?;
 
         let font_texture_id = self.device_objects.texture.get_id() as usize;
 
         let mut idx_start = 0;
         for cmd in draw_list.cmd_buffer {
-            // We don't support custom textures...yet!
+            // We do support custom textures now!
             let sampled = if cmd.texture_id as usize != font_texture_id {
                 let texture = self
                     .texture_cache

--- a/imgui-glium-textured-renderer/src/lib.rs
+++ b/imgui-glium-textured-renderer/src/lib.rs
@@ -1,0 +1,309 @@
+#[macro_use]
+extern crate glium;
+extern crate imgui;
+
+use glium::backend::{Context, Facade};
+use glium::index::{self, PrimitiveType};
+use glium::program;
+use glium::texture;
+use glium::vertex;
+use glium::{DrawError, GlObject, IndexBuffer, Program, Surface, Texture2d, VertexBuffer};
+use imgui::{
+    DrawList, FrameSize, ImDrawIdx, ImDrawVert, ImGui, TextureCache, TextureCacheError, TexturedUi,
+    Ui,
+};
+use std::borrow::Cow;
+use std::fmt;
+use std::rc::Rc;
+
+pub type RendererResult<T> = Result<T, RendererError>;
+
+#[derive(Clone, Debug)]
+pub enum RendererError {
+    Vertex(vertex::BufferCreationError),
+    Index(index::BufferCreationError),
+    Program(program::ProgramChooserCreationError),
+    Texture(texture::TextureCreationError),
+    Draw(DrawError),
+    UiTexture(TextureCacheError),
+}
+
+impl From<TextureCacheError> for RendererError {
+    fn from(item: TextureCacheError) -> RendererError {
+        RendererError::UiTexture(item)
+    }
+}
+
+impl fmt::Display for RendererError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use self::RendererError::*;
+        match *self {
+            Vertex(_) => write!(f, "Vertex buffer creation failed"),
+            Index(_) => write!(f, "Index buffer creation failed"),
+            Program(ref e) => write!(f, "Program creation failed: {}", e),
+            Texture(_) => write!(f, "Texture creation failed"),
+            Draw(ref e) => write!(f, "Drawing failed: {}", e),
+            UiTexture(ref e) => write!(f, "Invalid texture found: {}", e),
+        }
+    }
+}
+
+impl From<vertex::BufferCreationError> for RendererError {
+    fn from(e: vertex::BufferCreationError) -> RendererError {
+        RendererError::Vertex(e)
+    }
+}
+
+impl From<index::BufferCreationError> for RendererError {
+    fn from(e: index::BufferCreationError) -> RendererError {
+        RendererError::Index(e)
+    }
+}
+
+impl From<program::ProgramChooserCreationError> for RendererError {
+    fn from(e: program::ProgramChooserCreationError) -> RendererError {
+        RendererError::Program(e)
+    }
+}
+
+impl From<texture::TextureCreationError> for RendererError {
+    fn from(e: texture::TextureCreationError) -> RendererError {
+        RendererError::Texture(e)
+    }
+}
+
+impl From<DrawError> for RendererError {
+    fn from(e: DrawError) -> RendererError {
+        RendererError::Draw(e)
+    }
+}
+
+pub struct Renderer {
+    ctx: Rc<Context>,
+    device_objects: DeviceObjects,
+    texture_cache: TextureCache<Rc<Texture2d>>,
+}
+
+impl Renderer {
+    pub fn init<F: Facade>(imgui: &mut ImGui, ctx: &F) -> RendererResult<Renderer> {
+        let device_objects = DeviceObjects::init(imgui, ctx)?;
+        let mut texture_cache = TextureCache::default();
+        let font_texture_id = device_objects.texture.get_id() as usize;
+        texture_cache.set_font_texture_id(font_texture_id);
+
+        Ok(Renderer {
+            ctx: Rc::clone(ctx.get_context()),
+            device_objects,
+            texture_cache,
+        })
+    }
+
+    pub fn textured_ui<'a, 'b>(&'b mut self, ui: &'a Ui<'a>) -> TexturedUi<'a, 'b, Rc<Texture2d>> {
+        TexturedUi::init(&ui, &mut self.texture_cache)
+    }
+
+    pub fn render<'a, S: Surface>(&mut self, surface: &mut S, ui: Ui<'a>) -> RendererResult<()> {
+        let _ = self.ctx.insert_debug_marker("imgui-rs: starting rendering");
+        let FrameSize {
+            logical_size: (width, height),
+            hidpi_factor,
+        } = ui.frame_size();
+        if !(width > 0.0 && height > 0.0) {
+            return Ok(());
+        }
+        let fb_size = (
+            (width * hidpi_factor) as f32,
+            (height * hidpi_factor) as f32,
+        );
+
+        let matrix = [
+            [(2.0 / width) as f32, 0.0, 0.0, 0.0],
+            [0.0, (2.0 / -height) as f32, 0.0, 0.0],
+            [0.0, 0.0, -1.0, 0.0],
+            [-1.0, 1.0, 0.0, 1.0],
+        ];
+        let result = ui.render(|ui, mut draw_data| {
+            draw_data.scale_clip_rects(ui.imgui().display_framebuffer_scale());
+            for draw_list in draw_data.into_iter() {
+                self.render_draw_list(surface, &draw_list, fb_size, matrix, ui)?;
+            }
+            Ok(())
+        });
+        let _ = self.ctx.insert_debug_marker("imgui-rs: rendering finished");
+        result
+    }
+
+    fn render_draw_list<'a, S: Surface>(
+        &mut self,
+        surface: &mut S,
+        draw_list: &DrawList<'a>,
+        fb_size: (f32, f32),
+        matrix: [[f32; 4]; 4],
+        ui: &Ui<'a>,
+    ) -> RendererResult<()> {
+        use glium::{Blend, DrawParameters, Rect};
+
+        let (fb_width, fb_height) = fb_size;
+
+        self.device_objects
+            .upload_vertex_buffer(&self.ctx, draw_list.vtx_buffer)?;
+        self.device_objects
+            .upload_index_buffer(&self.ctx, draw_list.idx_buffer)?;
+        let texture = &self.device_objects.texture;
+
+        // let texture = self.bundle.data.texture = imgui.retrieve_texture(cmd.texture_id)?;
+
+        let font_texture_id = self.device_objects.texture.get_id() as usize;
+
+        let mut idx_start = 0;
+        for cmd in draw_list.cmd_buffer {
+            // We don't support custom textures...yet!
+            let sampled = if cmd.texture_id as usize != font_texture_id {
+                let texture = self
+                    .texture_cache
+                    .retrieve_texture(&(cmd.texture_id as usize))?;
+                texture.sampled()
+            } else {
+                texture.sampled()
+            };
+
+            let idx_end = idx_start + cmd.elem_count as usize;
+
+            surface.draw(
+                &self.device_objects.vertex_buffer,
+                &self
+                    .device_objects
+                    .index_buffer
+                    .slice(idx_start..idx_end)
+                    .expect("Invalid index buffer range"),
+                &self.device_objects.program,
+                &uniform! {
+                    matrix: matrix,
+                    tex: sampled
+                },
+                &DrawParameters {
+                    blend: Blend::alpha_blending(),
+                    scissor: Some(Rect {
+                        left: cmd.clip_rect.x.max(0.0).min(fb_width).round() as u32,
+                        bottom: (fb_height - cmd.clip_rect.w).max(0.0).min(fb_width).round() as u32,
+                        width: (cmd.clip_rect.z - cmd.clip_rect.x)
+                            .abs()
+                            .min(fb_width)
+                            .round() as u32,
+                        height: (cmd.clip_rect.w - cmd.clip_rect.y)
+                            .abs()
+                            .min(fb_height)
+                            .round() as u32,
+                    }),
+                    ..DrawParameters::default()
+                },
+            )?;
+
+            idx_start = idx_end;
+        }
+
+        Ok(())
+    }
+}
+
+pub struct DeviceObjects {
+    vertex_buffer: VertexBuffer<ImDrawVert>,
+    index_buffer: IndexBuffer<ImDrawIdx>,
+    program: Program,
+    texture: Texture2d,
+}
+
+fn compile_default_program<F: Facade>(
+    ctx: &F,
+) -> Result<Program, program::ProgramChooserCreationError> {
+    program!(
+        ctx,
+        400 => {
+            vertex: include_str!("shader/glsl_400.vert"),
+            fragment: include_str!("shader/glsl_400.frag"),
+            outputs_srgb: true,
+        },
+        130 => {
+            vertex: include_str!("shader/glsl_130.vert"),
+            fragment: include_str!("shader/glsl_130.frag"),
+            outputs_srgb: true,
+        },
+        110 => {
+            vertex: include_str!("shader/glsl_110.vert"),
+            fragment: include_str!("shader/glsl_110.frag"),
+            outputs_srgb: true,
+        },
+        300 es => {
+            vertex: include_str!("shader/glsles_300.vert"),
+            fragment: include_str!("shader/glsles_300.frag"),
+            outputs_srgb: true,
+        },
+        100 es => {
+            vertex: include_str!("shader/glsles_100.vert"),
+            fragment: include_str!("shader/glsles_100.frag"),
+            outputs_srgb: true,
+        },
+    )
+}
+
+impl DeviceObjects {
+    pub fn init<F: Facade>(im_gui: &mut ImGui, ctx: &F) -> RendererResult<DeviceObjects> {
+        use glium::texture::{ClientFormat, RawImage2d};
+
+        let vertex_buffer = VertexBuffer::empty_dynamic(ctx, 0)?;
+        let index_buffer = IndexBuffer::empty_dynamic(ctx, PrimitiveType::TrianglesList, 0)?;
+
+        let program = compile_default_program(ctx)?;
+        let texture = im_gui.prepare_font_texture(|handle| {
+            let data = RawImage2d {
+                data: Cow::Borrowed(handle.pixels),
+                width: handle.width,
+                height: handle.height,
+                format: ClientFormat::U8U8U8U8,
+            };
+            Texture2d::new(ctx, data)
+        })?;
+        im_gui.set_font_texture_id(texture.get_id() as usize);
+
+        Ok(DeviceObjects {
+            vertex_buffer: vertex_buffer,
+            index_buffer: index_buffer,
+            program: program,
+            texture: texture,
+        })
+    }
+    pub fn upload_vertex_buffer<F: Facade>(
+        &mut self,
+        ctx: &F,
+        vtx_buffer: &[ImDrawVert],
+    ) -> RendererResult<()> {
+        self.vertex_buffer.invalidate();
+        if let Some(slice) = self.vertex_buffer.slice_mut(0..vtx_buffer.len()) {
+            slice.write(vtx_buffer);
+            return Ok(());
+        }
+        self.vertex_buffer = VertexBuffer::dynamic(ctx, vtx_buffer)?;
+        let _ = ctx.get_context().insert_debug_marker(&format!(
+            "imgui-rs: resized vertex buffer to {} bytes",
+            self.vertex_buffer.get_size()
+        ));
+        Ok(())
+    }
+    pub fn upload_index_buffer<F: Facade>(
+        &mut self,
+        ctx: &F,
+        idx_buffer: &[ImDrawIdx],
+    ) -> RendererResult<()> {
+        self.index_buffer.invalidate();
+        if let Some(slice) = self.index_buffer.slice_mut(0..idx_buffer.len()) {
+            slice.write(idx_buffer);
+            return Ok(());
+        }
+        self.index_buffer = IndexBuffer::dynamic(ctx, PrimitiveType::TrianglesList, idx_buffer)?;
+        let _ = ctx.get_context().insert_debug_marker(&format!(
+            "imgui-rs: resized index buffer to {} bytes",
+            self.index_buffer.get_size()
+        ));
+        Ok(())
+    }
+}

--- a/imgui-glium-textured-renderer/src/shader/glsl_110.frag
+++ b/imgui-glium-textured-renderer/src/shader/glsl_110.frag
@@ -1,0 +1,13 @@
+#version 110
+
+uniform sampler2D tex;
+
+varying vec2 f_uv;
+varying vec4 f_color;
+
+// Built-in:
+// vec4 gl_FragColor
+
+void main() {
+  gl_FragColor = f_color * texture2D(tex, f_uv.st);
+}

--- a/imgui-glium-textured-renderer/src/shader/glsl_110.vert
+++ b/imgui-glium-textured-renderer/src/shader/glsl_110.vert
@@ -1,0 +1,19 @@
+#version 110
+
+uniform mat4 matrix;
+
+attribute vec2 pos;
+attribute vec2 uv;
+attribute vec4 col;
+
+varying vec2 f_uv;
+varying vec4 f_color;
+
+// Built-in:
+// vec4 gl_Position
+
+void main() {
+  f_uv = uv;
+  f_color = col / 255.0;
+  gl_Position = matrix * vec4(pos.xy, 0, 1);
+}

--- a/imgui-glium-textured-renderer/src/shader/glsl_130.frag
+++ b/imgui-glium-textured-renderer/src/shader/glsl_130.frag
@@ -1,0 +1,12 @@
+#version 130
+
+uniform sampler2D tex;
+
+in vec2 f_uv;
+in vec4 f_color;
+
+out vec4 out_color;
+
+void main() {
+  out_color = f_color * texture(tex, f_uv.st);
+}

--- a/imgui-glium-textured-renderer/src/shader/glsl_130.vert
+++ b/imgui-glium-textured-renderer/src/shader/glsl_130.vert
@@ -1,0 +1,19 @@
+#version 130
+
+uniform mat4 matrix;
+
+in vec2 pos;
+in vec2 uv;
+in vec4 col;
+
+out vec2 f_uv;
+out vec4 f_color;
+
+// Built-in:
+// vec4 gl_Position
+
+void main() {
+  f_uv = uv;
+  f_color = col / 255.0;
+  gl_Position = matrix * vec4(pos.xy, 0, 1);
+}

--- a/imgui-glium-textured-renderer/src/shader/glsl_400.frag
+++ b/imgui-glium-textured-renderer/src/shader/glsl_400.frag
@@ -1,0 +1,12 @@
+#version 400
+
+uniform sampler2D tex;
+
+in vec2 f_uv;
+in vec4 f_color;
+
+out vec4 out_color;
+
+void main() {
+  out_color = f_color * texture(tex, f_uv.st);
+}

--- a/imgui-glium-textured-renderer/src/shader/glsl_400.vert
+++ b/imgui-glium-textured-renderer/src/shader/glsl_400.vert
@@ -1,0 +1,19 @@
+#version 400
+
+uniform mat4 matrix;
+
+in vec2 pos;
+in vec2 uv;
+in vec4 col;
+
+out vec2 f_uv;
+out vec4 f_color;
+
+// Built-in:
+// vec4 gl_Position
+
+void main() {
+  f_uv = uv;
+  f_color = col / 255.0;
+  gl_Position = matrix * vec4(pos.xy, 0, 1);
+}

--- a/imgui-glium-textured-renderer/src/shader/glsles_100.frag
+++ b/imgui-glium-textured-renderer/src/shader/glsles_100.frag
@@ -1,0 +1,13 @@
+#version 100
+
+uniform sampler2D tex;
+
+varying mediump vec2 f_uv;
+varying lowp vec4 f_color;
+
+// Built-in:
+// vec4 gl_FragColor
+
+void main() {
+  gl_FragColor = f_color * texture2D(tex, f_uv.st);
+}

--- a/imgui-glium-textured-renderer/src/shader/glsles_100.vert
+++ b/imgui-glium-textured-renderer/src/shader/glsles_100.vert
@@ -1,0 +1,19 @@
+#version 100
+
+uniform mat4 matrix;
+
+attribute mediump vec2 pos;
+attribute mediump vec2 uv;
+attribute lowp vec4 col;
+
+varying mediump vec2 f_uv;
+varying lowp vec4 f_color;
+
+// Built-in:
+// vec4 gl_Position
+
+void main() {
+  f_uv = uv;
+  f_color = col / 255.0;
+  gl_Position = matrix * vec4(pos.xy, 0, 1);
+}

--- a/imgui-glium-textured-renderer/src/shader/glsles_300.frag
+++ b/imgui-glium-textured-renderer/src/shader/glsles_300.frag
@@ -1,0 +1,12 @@
+#version 300 es
+
+uniform sampler2D tex;
+
+in mediump vec2 f_uv;
+in lowp vec4 f_color;
+
+out lowp vec4 out_color;
+
+void main() {
+  out_color = f_color * texture(tex, f_uv.st);
+}

--- a/imgui-glium-textured-renderer/src/shader/glsles_300.vert
+++ b/imgui-glium-textured-renderer/src/shader/glsles_300.vert
@@ -1,0 +1,19 @@
+#version 300 es
+
+uniform mat4 matrix;
+
+in mediump vec2 pos;
+in mediump vec2 uv;
+in lowp vec4 col;
+
+out mediump vec2 f_uv;
+out lowp vec4 f_color;
+
+// Built-in:
+// vec4 gl_Position
+
+void main() {
+  f_uv = uv;
+  f_color = col / 255.0;
+  gl_Position = matrix * vec4(pos.xy, 0, 1);
+}

--- a/imgui-glutin-support/Cargo.toml
+++ b/imgui-glutin-support/Cargo.toml
@@ -12,5 +12,5 @@ categories = ["gui"]
 travis-ci = { repository = "Gekkio/imgui-rs" }
 
 [dependencies]
-glutin = "0.18"
+glutin = ">= 0.17, <= 0.18"
 imgui = { version = "0.0.21-pre", path = "../" }

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,4 +1,4 @@
-use super::{ImTextureID, ImVec2, ImVec4};
+use super::{ImVec2, ImVec4};
 use std::os::raw::c_void;
 use texture_cache::TextureID;
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,0 +1,90 @@
+use super::{ImTextureID, ImVec2, ImVec4};
+use std::os::raw::c_void;
+use texture_cache::TextureID;
+
+use sys;
+
+/// Represent an image about to be drawn
+/// See [`Ui::image`].
+///
+/// Create your image using the builder pattern then [`Image::build`] it.
+pub struct Image<E> {
+    /// we use Result to allow postponing any construction errors to the build call
+    texture_id: Result<TextureID, E>,
+    size: ImVec2,
+    uv0: ImVec2,
+    uv1: ImVec2,
+    tint_col: ImVec4,
+    border_col: ImVec4,
+}
+
+impl<E> Image<E> {
+    pub fn new<S>(texture: Result<TextureID, E>, size: S) -> Image<E>
+    where
+        S: Into<ImVec2>,
+    {
+        const DEFAULT_UV0: ImVec2 = ImVec2 { x: 0.0, y: 0.0 };
+        const DEFAULT_UV1: ImVec2 = ImVec2 { x: 1.0, y: 1.0 };
+        const DEFAULT_TINT_COL: ImVec4 = ImVec4 {
+            x: 1.0,
+            y: 1.0,
+            z: 1.0,
+            w: 1.0,
+        };
+        const DEFAULT_BORDER_COL: ImVec4 = ImVec4 {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+            w: 0.0,
+        };
+        Image {
+            texture_id: texture,
+            size: size.into(),
+            uv0: DEFAULT_UV0,
+            uv1: DEFAULT_UV1,
+            tint_col: DEFAULT_TINT_COL,
+            border_col: DEFAULT_BORDER_COL,
+        }
+    }
+
+    /// Set uv0 (default `[0.0, 0.0]`)
+    pub fn uv0<T: Into<ImVec2>>(mut self, uv0: T) -> Self {
+        self.uv0 = uv0.into();
+        self
+    }
+
+    /// Set uv1 (default `[1.0, 1.0]`)
+    pub fn uv1<T: Into<ImVec2>>(mut self, uv1: T) -> Self {
+        self.uv1 = uv1.into();
+        self
+    }
+
+    /// Set tint color (default: no tint color)
+    pub fn tint_col<T: Into<ImVec4>>(mut self, tint_col: T) -> Self {
+        self.tint_col = tint_col.into();
+        self
+    }
+
+    /// Set border color (default: no border)
+    pub fn border_col<T: Into<ImVec4>>(mut self, border_col: T) -> Self {
+        self.border_col = border_col.into();
+        self
+    }
+
+    /// Draw image where the cursor currently is
+    /// here we can finally bubble up the error
+    pub fn build(self) -> Result<(), E> {
+        let id = self.texture_id?;
+        unsafe {
+            sys::igImage(
+                id as *mut c_void,
+                self.size,
+                self.uv0,
+                self.uv1,
+                self.tint_col,
+                self.border_col,
+            );
+        }
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 pub extern crate imgui_sys as sys;
 
+use std::any::Any;
+use std::cell::RefCell;
 use std::ffi::CStr;
 use std::mem;
 use std::os::raw::{c_char, c_float, c_int, c_uchar, c_void};
@@ -18,6 +20,7 @@ pub use drag::{
     DragInt4, DragIntRange2,
 };
 pub use fonts::{FontGlyphRange, ImFont, ImFontAtlas, ImFontConfig};
+pub use image::Image;
 pub use input::{
     InputFloat, InputFloat2, InputFloat3, InputFloat4, InputInt, InputInt2, InputInt3, InputInt4,
     InputText, InputTextMultiline,
@@ -35,8 +38,10 @@ pub use style::StyleVar;
 pub use sys::{
     ImDrawIdx, ImDrawVert, ImGuiCol, ImGuiColorEditFlags, ImGuiCond, ImGuiHoveredFlags,
     ImGuiInputTextFlags, ImGuiKey, ImGuiMouseCursor, ImGuiSelectableFlags, ImGuiStyle,
-    ImGuiTreeNodeFlags, ImGuiWindowFlags, ImVec2, ImVec4,
+    ImGuiTreeNodeFlags, ImGuiWindowFlags, ImTextureID, ImVec2, ImVec4,
 };
+pub use texture_cache::{TextureCache, TextureCacheError};
+pub use texture_ui::TexturedUi;
 pub use trees::{CollapsingHeader, TreeNode};
 pub use window::Window;
 pub use window_draw_list::{ChannelsSplit, ImColor, WindowDrawList};
@@ -45,6 +50,7 @@ mod child_frame;
 mod color_editors;
 mod drag;
 mod fonts;
+mod image;
 mod input;
 mod menus;
 mod plothistogram;
@@ -53,6 +59,8 @@ mod progressbar;
 mod sliders;
 mod string;
 mod style;
+mod texture_cache;
+mod texture_ui;
 mod trees;
 mod window;
 mod window_draw_list;
@@ -146,7 +154,7 @@ impl ImGui {
     pub fn fonts(&mut self) -> ImFontAtlas {
         unsafe { ImFontAtlas::from_ptr(self.io_mut().fonts) }
     }
-    pub fn prepare_texture<'a, F, T>(&mut self, f: F) -> T
+    pub fn prepare_font_texture<'a, F, T>(&mut self, f: F) -> T
     where
         F: FnOnce(TextureHandle<'a>) -> T,
     {
@@ -170,7 +178,7 @@ impl ImGui {
             })
         }
     }
-    pub fn set_texture_id(&mut self, value: usize) {
+    pub fn set_font_texture_id(&mut self, value: usize) {
         self.fonts().set_texture_id(value);
     }
     pub fn set_ini_filename(&mut self, value: Option<ImString>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 pub extern crate imgui_sys as sys;
 
-use std::any::Any;
-use std::cell::RefCell;
 use std::ffi::CStr;
 use std::mem;
 use std::os::raw::{c_char, c_float, c_int, c_uchar, c_void};

--- a/src/texture_cache.rs
+++ b/src/texture_cache.rs
@@ -29,7 +29,7 @@ pub struct TextureCache<T> {
     name_map: HashMap<String, TextureID>,
     /// maps between usizes and the underlying texture objects
     texture_map: HashMap<TextureID, T>,
-    /// holds the id of the font_texture - used to avoid colissions
+    /// holds the id of the font_texture - used to avoid collisions
     font_texture_id: Option<TextureID>,
 }
 
@@ -67,7 +67,7 @@ impl<T> TextureCache<T> {
     pub fn set_font_texture_id(&mut self, font_texture_id: TextureID) {
         self.font_texture_id = Some(font_texture_id);
 
-        // avoid the colission
+        // avoid the collision
         if self.last_id == font_texture_id {
             self.last_id += 1;
         }
@@ -86,7 +86,7 @@ impl<T> TextureCache<T> {
         name: String,
         texture: T,
     ) -> Result<TextureID, TextureCacheError> {
-        // we need to know what ids fonts will be using to avoid colissions.
+        // we need to know what ids fonts will be using to avoid collisions.
         let font_id = match self.font_texture_id.as_ref() {
             Some(font_id) => *font_id,
             None => return Err(TextureCacheError::FontTextureNotSet),
@@ -102,7 +102,7 @@ impl<T> TextureCache<T> {
                 self.texture_map.insert(new_id, texture);
 
                 self.last_id += 1;
-                // avoid colission with the font texture
+                // avoid collision with the font texture
                 if self.last_id == font_id {
                     self.last_id += 1;
                 }
@@ -121,7 +121,7 @@ impl<T> TextureCache<T> {
         name: &str,
         texture: T,
     ) -> Result<(TextureID, T), TextureCacheError> {
-        // we need to know what ids fonts will be using to avoid colissions.
+        // we need to know what ids fonts will be using to avoid collisions.
         if self.font_texture_id.is_none() {
             return Err(TextureCacheError::FontTextureNotSet);
         }
@@ -145,7 +145,7 @@ impl<T> TextureCache<T> {
 
     /// Removes a named texture from the texture cache, also invalidating the texture's id
     pub fn remove_texture(&mut self, name: &str) -> Result<(TextureID, T), TextureCacheError> {
-        // we need to know what ids fonts will be using to avoid colissions.
+        // we need to know what ids fonts will be using to avoid collisions.
         if self.font_texture_id.is_none() {
             return Err(TextureCacheError::FontTextureNotSet);
         }
@@ -180,7 +180,7 @@ impl<T> TextureCache<T> {
     /// Retrieves the texture object given an id
     /// Used within the render_draw_list functions - `imgui.texture_cache.retrieve_texture(cmd.texture_id)?`
     pub fn retrieve_texture(&self, id: &TextureID) -> Result<&T, TextureCacheError> {
-        // we need to know what ids fonts will be using to avoid colissions.
+        // we need to know what ids fonts will be using to avoid collisions.
         if self.font_texture_id.is_none() {
             return Err(TextureCacheError::FontTextureNotSet);
         }
@@ -220,7 +220,7 @@ mod test {
     }
 
     #[test]
-    fn name_colissions_return_err() {
+    fn name_collisions_return_err() {
         let mut cache = construct_texture_cache();
         let insert_result = cache.add_texture("example_name".into(), 10);
         let insert_result = cache.add_texture("example_name".into(), 10);

--- a/src/texture_cache.rs
+++ b/src/texture_cache.rs
@@ -1,0 +1,281 @@
+use std::collections::hash_map::{Entry, HashMap};
+use std::error::Error;
+use std::fmt;
+use std::fmt::{Display, Formatter};
+pub type TextureID = usize;
+
+/// The texture cache provides two core functionalities:
+///   - it provides a mapping between String to usizes
+///       - these usizes are given to imgui to manage
+///   - it provides a mapping between usizes to a generic type T
+///       - this type is set by the calling library
+///
+/// Notes
+/// ==========
+/// There is a core conflict with the way in which glium and gfx deal with textures:
+///   - in gfx, textures are handles to their underlying data, and thus can be cloned
+///   - in glium, Texture2D, textures are the owners of their underlying data and can
+///     not be cloned
+/// Thus to meet the lowest common denominator, we need anything representing textures to
+/// be clonable - which probably means using Rc<Texture2D> for glium.
+///
+/// We also can not just use a list as the `texture_map`, as it would make removing textures
+/// impossible. Potentially an Arena structure could be used, but for now we're using a simple
+/// approach
+pub struct TextureCache<T> {
+    /// used to provide unique ids for each texture
+    last_id: usize,
+    /// maps between strings and usizes - used when constructing textures
+    name_map: HashMap<String, TextureID>,
+    /// maps between usizes and the underlying texture objects
+    texture_map: HashMap<TextureID, T>,
+    /// holds the id of the font_texture - used to avoid colissions
+    font_texture_id: Option<TextureID>,
+}
+
+impl<T> Default for TextureCache<T> {
+    fn default() -> Self {
+        TextureCache {
+            last_id: 0,
+            name_map: HashMap::default(),
+            texture_map: HashMap::default(),
+            font_texture_id: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TextureCacheError {
+    IDNotFound,
+    NameExists,
+    NameNotFound,
+    FontTextureNotSet,
+}
+impl Display for TextureCacheError {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+        match self {
+            TextureCacheError::IDNotFound => write!(f, "Provided TextureID not found"),
+            TextureCacheError::NameExists => write!(f, "Attempted rebinding of existing name"),
+            TextureCacheError::NameNotFound => write!(f, "Provided name not found"),
+            TextureCacheError::FontTextureNotSet => write!(f, "Font Texture has not set"),
+        }
+    }
+}
+impl Error for TextureCacheError {}
+
+impl<T> TextureCache<T> {
+    pub fn set_font_texture_id(&mut self, font_texture_id: TextureID) {
+        self.font_texture_id = Some(font_texture_id);
+
+        // avoid the colission
+        if self.last_id == font_texture_id {
+            self.last_id += 1;
+        }
+    }
+}
+
+// Name interface
+// =================
+// Contains all methods for manipulating the binding between names and textures
+impl<T> TextureCache<T> {
+    /// Adds a mapping for a texture, returning a unique id that can be used to retrieve the texture
+    ///
+    /// called by `ui.make_texture("")`
+    pub fn add_texture(
+        &mut self,
+        name: String,
+        texture: T,
+    ) -> Result<TextureID, TextureCacheError> {
+        // we need to know what ids fonts will be using to avoid colissions.
+        let font_id = match self.font_texture_id.as_ref() {
+            Some(font_id) => *font_id,
+            None => return Err(TextureCacheError::FontTextureNotSet),
+        };
+
+        let entry = self.name_map.entry(name);
+        let new_id = self.last_id;
+        match entry {
+            Entry::Vacant(vacant_entry) => {
+                // first store the mapping from the name to the id
+                vacant_entry.insert(new_id);
+                // then store the mapping from the id to the texture
+                self.texture_map.insert(new_id, texture);
+
+                self.last_id += 1;
+                // avoid colission with the font texture
+                if self.last_id == font_id {
+                    self.last_id += 1;
+                }
+
+                Ok(new_id)
+            }
+            Entry::Occupied(_) => Err(TextureCacheError::NameExists),
+        }
+    }
+
+    /// Replaces a texture's mapping, which means that subsequent retrievals with the unique id
+    /// will return a different texture.
+    /// returns the old texture although currently this is not used.
+    pub fn replace_texture(
+        &mut self,
+        name: &str,
+        texture: T,
+    ) -> Result<(TextureID, T), TextureCacheError> {
+        // we need to know what ids fonts will be using to avoid colissions.
+        if self.font_texture_id.is_none() {
+            return Err(TextureCacheError::FontTextureNotSet);
+        }
+
+        if let Some(id) = self.name_map.get(name) {
+            if let Entry::Occupied(mut entry) = self.texture_map.entry(*id) {
+                let old_texture = entry.insert(texture);
+                let id = *id;
+
+                Ok((id, old_texture))
+            } else {
+                // this id has been retrieved internally, and so should always be valid
+                // or rather, it is a semantic error for the texture cache to contain a
+                // a name that doesn't bind to a texture
+                unreachable!();
+            }
+        } else {
+            Err(TextureCacheError::NameNotFound)
+        }
+    }
+
+    /// Removes a named texture from the texture cache, also invalidating the texture's id
+    pub fn remove_texture(&mut self, name: &str) -> Result<(TextureID, T), TextureCacheError> {
+        // we need to know what ids fonts will be using to avoid colissions.
+        if self.font_texture_id.is_none() {
+            return Err(TextureCacheError::FontTextureNotSet);
+        }
+
+        if let Some(id) = self.name_map.remove(name) {
+            if let Some(old_texture) = self.texture_map.remove(&id) {
+                Ok((id, old_texture))
+            } else {
+                // this id has been retrieved internally, and so should always be valid
+                // or rather, it is a semantic error for the texture cache to contain a
+                // a name that doesn't bind to a texture
+                unreachable!();
+            }
+        } else {
+            Err(TextureCacheError::NameNotFound)
+        }
+    }
+
+    /// Returns the id for a texture - called internally by `ui.image("name",...)`
+    pub fn retrieve_texture_id(&self, name: &str) -> Result<TextureID, TextureCacheError> {
+        self.name_map
+            .get(name)
+            .map(|id| *id)
+            .ok_or(TextureCacheError::NameNotFound)
+    }
+}
+
+// ID interface
+// =================
+// Contains all methods for retrieving textures from ids
+impl<T> TextureCache<T> {
+    /// Retrieves the texture object given an id
+    /// Used within the render_draw_list functions - `imgui.texture_cache.retrieve_texture(cmd.texture_id)?`
+    pub fn retrieve_texture(&self, id: &TextureID) -> Result<&T, TextureCacheError> {
+        // we need to know what ids fonts will be using to avoid colissions.
+        if self.font_texture_id.is_none() {
+            return Err(TextureCacheError::FontTextureNotSet);
+        }
+
+        // Note: Is it worth cloning here - or should the Clone constraint just be removed?
+        self.texture_map
+            .get(id)
+            .ok_or(TextureCacheError::IDNotFound)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn construct_texture_cache() -> TextureCache<i32> {
+        let mut cache = TextureCache::<i32>::default();
+        cache.set_font_texture_id(0);
+        cache
+    }
+
+    #[test]
+    fn inserting_textures_returns_id() {
+        let mut cache = construct_texture_cache();
+        let insert_result = cache.add_texture("example_name".into(), 10);
+        assert!(insert_result.is_ok());
+    }
+
+    #[test]
+    fn inserting_textures_returns_unique_id() {
+        let mut cache = construct_texture_cache();
+        let insert_result = cache.add_texture("example_name".into(), 10);
+        let id = insert_result.unwrap();
+        let insert_result = cache.add_texture("example_name_2".into(), 10);
+        let id2 = insert_result.unwrap();
+        assert_ne!(id, id2);
+    }
+
+    #[test]
+    fn name_colissions_return_err() {
+        let mut cache = construct_texture_cache();
+        let insert_result = cache.add_texture("example_name".into(), 10);
+        let insert_result = cache.add_texture("example_name".into(), 10);
+        assert!(insert_result.is_err());
+    }
+
+    #[test]
+    fn inserted_items_can_be_retrieved_by_id() {
+        let mut cache = construct_texture_cache();
+        let id = cache.add_texture("example_name".into(), 10).unwrap();
+        let internal = cache.retrieve_texture(&id).unwrap();
+        assert_eq!(*internal, 10);
+    }
+
+    #[test]
+    fn inserted_items_id_can_be_retrieved_by_name() {
+        let mut cache = construct_texture_cache();
+        let id = cache.add_texture("example_name".into(), 10).unwrap();
+        let other_id = cache.retrieve_texture_id("example_name").unwrap();
+        assert_eq!(other_id, id);
+    }
+
+    #[test]
+    fn removing_items_returns_old_value() {
+        let mut cache = construct_texture_cache();
+        cache.add_texture("example_name".into(), 10);
+        let (_, value) = cache.remove_texture("example_name").unwrap();
+        assert_eq!(value, 10);
+    }
+
+    #[test]
+    fn retrieving_removed_items_by_id_fails() {
+        let mut cache = construct_texture_cache();
+        let id = cache.add_texture("example_name".into(), 10).unwrap();
+        cache.remove_texture("example_name").unwrap();
+        let result = cache.retrieve_texture(&id);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn retrieving_removed_item_ids_by_name_fails() {
+        let mut cache = construct_texture_cache();
+        cache.add_texture("example_name".into(), 10);
+        cache.remove_texture("example_name").unwrap();
+        let result = cache.retrieve_texture_id("example_name");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn replacing_item_updates_value() {
+        let mut cache = construct_texture_cache();
+        let id = cache.add_texture("example_name".into(), 10).unwrap();
+        cache.replace_texture("example_name", 20).unwrap();
+        let result = cache.retrieve_texture(&id).unwrap();
+        assert_eq!(*result, 20);
+    }
+
+}

--- a/src/texture_ui.rs
+++ b/src/texture_ui.rs
@@ -1,0 +1,64 @@
+use super::{ImVec2, Image, TextureCache, TextureCacheError, Ui};
+
+use std::cell::RefCell;
+use std::ops::Deref;
+
+/// A wrapper around the Ui<'a> to allow it to render custom textures.
+pub struct TexturedUi<'ui, 'tc, T: 'tc> {
+    ui: &'ui Ui<'ui>,
+    texture_cache: RefCell<&'tc mut TextureCache<T>>,
+}
+
+impl<'ui, 'tc, T> Deref for TexturedUi<'ui, 'tc, T> {
+    type Target = Ui<'ui>;
+    fn deref(&self) -> &Ui<'ui> {
+        &self.ui
+    }
+}
+
+impl<'ui, 'tc, T> TexturedUi<'ui, 'tc, T> {
+    pub fn init(ui: &'ui Ui<'ui>, texture_cache: &'tc mut TextureCache<T>) -> Self {
+        TexturedUi {
+            ui,
+            texture_cache: RefCell::new(texture_cache),
+        }
+    }
+}
+
+/// # Texture related functions
+impl<'ui, 'tc, T> TexturedUi<'ui, 'tc, T> {
+    /// Register a texture with the api
+    pub fn make_texture(&self, name: String, texture: T) -> Result<(), TextureCacheError> {
+        self.texture_cache.borrow_mut().add_texture(name, texture)?;
+        Ok(())
+    }
+
+    /// Replaces the texture bound to a name
+    pub fn replace_texture(&self, name: &str, texture: T) -> Result<(), TextureCacheError> {
+        self.texture_cache
+            .borrow_mut()
+            .replace_texture(name, texture)?;
+        Ok(())
+    }
+
+    /// Removes a binding between a texture and a name
+    pub fn remove_texture(&self, name: &str) -> Result<T, TextureCacheError> {
+        let (_, tex) = self.texture_cache.borrow_mut().remove_texture(name)?;
+        Ok(tex)
+    }
+}
+
+/// # Image related functions
+impl<'ui, 'tc, T> TexturedUi<'ui, 'tc, T> {
+    /// constructs a new image using a previously registered texture
+    pub fn image<S>(&self, texture_name: &str, size: S) -> Image<TextureCacheError>
+    where
+        S: Into<ImVec2>,
+    {
+        let texture = self
+            .texture_cache
+            .borrow()
+            .retrieve_texture_id(texture_name);
+        Image::new(texture, size)
+    }
+}


### PR DESCRIPTION
The other thread  #122  on Custom texture support #65 

hasn't been active in a while, and I really needed custom texture support, so I've provided an alternate implementation based on the discussion on that thread. Many thanks to @malikolivier for his implementation which provided a handy starting point.

Currently the custom texture support is only implemented for `glium`, however, I believe the implementation is sufficiently generalized such that it would be easy to extend it to `gfx` - if the implementation looks good, I can get to work on extending it to `gfx`.

### Core Logic
The core logic of the implementation is encapsulated within the `TextureCache<T>` struct, located within `src/texture_cache.rs`.

This struct provides a mapping from `String -> usize -> T`, with the intention being that once a  texture type `T` is bound to a `String`, subsequent calls will pass the `usize` to `imgui` to manage, and then at the point of rendering, the `usize`'s can be mapped back into `T`. This avoids the issue found in the alternate implementation where an unsafe mapping had to be made from `ImTextureID` to `T`.

### Integration with existing api
Next, from looking at both the `glium` and `gfx` Texture structs, it seems that they are too different on a conceptual level, to use a single trait to represent them - this means that trait objects won't be idiomatic to implement.

Now, due to the fact that a copy of `Ui<'a>` is stored globally within `CURRENT_UI`, it is not possible to parameterize the `ImGui` or `Ui` structs with the type of the texture T as const generics aren't supported.

So to work around these limitations, in the implementation of the `imgui_glium_textured_renderer::Renderer`, I provide a wrapper around `Ui<'a>`,  `TexturedUi<'a,'b,T>`, which holds a reference to the the Renderer's texture cache, and thereby imbuing the `Ui<'a>` struct with capabilities to make and remove textures.

###  Example
I have also provided an example (once again based off the ones provided by @malikolivier) - the API for using textures is also based off his implementation:

As a quick reference, using api would look like:
```
if !init {
    ui.make_texture("#textureA".into(), /* Make a texture */);
}

ui.window().build(|| {
   ui.image("#textureA").build(); // will return an error if textureA is not defined.
});

``` 

![textures](https://user-images.githubusercontent.com/23038502/44622341-79709f80-a8ae-11e8-80bd-80792d75f6be.png)