### PR TITLE
Add Clone to ImGuiStyle

### DIFF
--- a/imgui-sys/src/lib.rs
+++ b/imgui-sys/src/lib.rs
@@ -545,6 +545,7 @@ impl Into<(f32, f32, f32, f32)> for ImVec4 {
 
 /// Runtime data for styling/colors
 #[repr(C)]
+#[derive(Clone)]
 pub struct ImGuiStyle {
     /// Global alpha applies to everything in ImGui
     pub alpha: c_float,


### PR DESCRIPTION
It should probably be `Debug` and `PartialEq` too, but the `[ImVec4; 44]` gets in the way.

Useful in the situation that you need to save/restore styles in any way.