### PR TITLE
Add custom texture support (both renderers)

### DIFF
--- a/imgui-gfx-renderer/src/lib.rs
+++ b/imgui-gfx-renderer/src/lib.rs
@@ -227,7 +227,7 @@ impl<R: Resources> Renderer<R> {
 
         self.bundle.slice.start = 0;
         for cmd in draw_list.cmd_buffer {
-            if let Some(tex) = self.textures.get(cmd.texture_id as usize) {
+            if let Some(tex) = self.textures.get(cmd.texture_id.into()) {
                 // cloning handles is okay, since they're Arcs internally
                 self.bundle.data.tex = tex.clone();
             }

--- a/imgui-gfx-renderer/src/lib.rs
+++ b/imgui-gfx-renderer/src/lib.rs
@@ -6,7 +6,8 @@ use gfx::handle::{Buffer, RenderTargetView};
 use gfx::memory::Bind;
 use gfx::texture::{FilterMethod, SamplerInfo, WrapMode};
 use gfx::traits::FactoryExt;
-use gfx::{Bundle, CommandBuffer, Encoder, Factory, IntoIndexBuffer, Rect, Resources, Slice};
+use gfx::{CommandBuffer, Encoder, Factory, IntoIndexBuffer, Rect, Resources, Slice};
+use gfx::pso::{PipelineData, PipelineState};
 use imgui::{DrawList, FrameSize, ImDrawIdx, ImDrawVert, ImGui, Ui, Textures};
 
 pub type RendererResult<T> = Result<T, RendererError>;
@@ -43,7 +44,42 @@ impl From<gfx::CombinedError> for RendererError {
     }
 }
 
-gfx_defines!{
+// Based on gfx_defines! / gfx_pipeline!, to allow for not having to clone Arcs
+// every draw call when selecting which texture is going to be shown.
+macro_rules! extended_defines {
+    (pipeline $module:ident { $( $field:ident: $ty:ty = $value:expr, )* }) => {
+        #[allow(missing_docs)]
+        mod $module {
+            #[allow(unused_imports)]
+            use super::*;
+            #[allow(unused_imports)]
+            use super::gfx;
+            gfx_pipeline_inner!{ $(
+                $field: $ty,
+            )*}
+
+            pub fn new() -> Init<'static> {
+                Init {
+                    $( $field: $value, )*
+                }
+            }
+
+            pub struct BorrowedData<'a, R: Resources> {
+                $(pub $field: &'a <$ty as DataBind<R>>::Data,)*
+            }
+
+            impl<'a, R: Resources> gfx::pso::PipelineData<R> for BorrowedData<'a, R> {
+                type Meta = pipe::Meta;
+
+                fn bake_to(&self, out: &mut RawDataSet<R>, meta: &Self::Meta, man: &mut gfx::handle::Manager<R>, access: &mut AccessInfo<R>) {
+                    $(meta.$field.bind_to(out, &self.$field, man, access);)*
+                }
+            }
+        }
+    }
+}
+
+extended_defines! {
     pipeline pipe {
         vertex_buffer: gfx::VertexBuffer<ImDrawVert> = (),
         matrix: gfx::Global<[[f32; 4]; 4]> = "matrix",
@@ -100,6 +136,7 @@ pub struct Renderer<R: Resources> {
     bundle: Bundle<R, pipe::Data<R>>,
     index_buffer: Buffer<R, u16>,
     textures: Textures<Texture<R>>,
+    backup_texture: Texture<R>,
 }
 
 impl<R: Resources> Renderer<R> {
@@ -140,23 +177,6 @@ impl<R: Resources> Renderer<R> {
         let mut textures = Textures::new();
         imgui.set_texture_id(textures.insert(pair.clone()));
 
-        let data = pipe::Data {
-            vertex_buffer: vertex_buffer,
-            matrix: [
-                [0.0, 0.0, 0.0, 0.0],
-                [0.0, 0.0, 0.0, 0.0],
-                [0.0, 0.0, -1.0, 0.0],
-                [-1.0, 1.0, 0.0, 1.0],
-            ],
-            tex: pair,
-            out: out,
-            scissor: Rect {
-                x: 0,
-                y: 0,
-                w: 0,
-                h: 0,
-            },
-        };
         let slice = Slice {
             start: 0,
             end: 0,
@@ -165,14 +185,20 @@ impl<R: Resources> Renderer<R> {
             buffer: index_buffer.clone().into_index_buffer(factory),
         };
         Ok(Renderer {
-            bundle: Bundle::new(slice, pso, data),
+            bundle: Bundle {
+                slice: slice,
+                pso: pso,
+                vertex_buffer: vertex_buffer,
+                out: out,
+            },
             index_buffer: index_buffer,
             textures: textures,
+            backup_texture: pair,
         })
     }
 
     pub fn update_render_target(&mut self, out: RenderTargetView<R, gfx::format::Rgba8>) {
-        self.bundle.data.out = out;
+        self.bundle.out = out;
     }
 
     pub fn textures(&mut self) -> &mut Textures<Texture<R>> {
@@ -198,7 +224,7 @@ impl<R: Resources> Renderer<R> {
             (height * hidpi_factor) as f32,
         );
 
-        self.bundle.data.matrix = [
+        let matrix = [
             [(2.0 / width) as f32, 0.0, 0.0, 0.0],
             [0.0, (2.0 / -height) as f32, 0.0, 0.0],
             [0.0, 0.0, -1.0, 0.0],
@@ -208,7 +234,7 @@ impl<R: Resources> Renderer<R> {
         ui.render(|ui, mut draw_data| {
             draw_data.scale_clip_rects(ui.imgui().display_framebuffer_scale());
             for draw_list in &draw_data {
-                self.render_draw_list(factory, encoder, &draw_list, fb_size)?;
+                self.render_draw_list(factory, encoder, &draw_list, fb_size, &matrix)?;
             }
             Ok(())
         })
@@ -219,6 +245,7 @@ impl<R: Resources> Renderer<R> {
         encoder: &mut Encoder<R, C>,
         draw_list: &DrawList<'a>,
         fb_size: (f32, f32),
+        matrix: &[[f32; 4]; 4],
     ) -> RendererResult<()> {
         let (fb_width, fb_height) = fb_size;
 
@@ -227,13 +254,10 @@ impl<R: Resources> Renderer<R> {
 
         self.bundle.slice.start = 0;
         for cmd in draw_list.cmd_buffer {
-            if let Some(tex) = self.textures.get(cmd.texture_id.into()) {
-                // cloning handles is okay, since they're Arcs internally
-                self.bundle.data.tex = tex.clone();
-            }
+            let tex = self.textures.get(cmd.texture_id.into()).unwrap_or(&self.backup_texture);
 
             self.bundle.slice.end = self.bundle.slice.start + cmd.elem_count;
-            self.bundle.data.scissor = Rect {
+            let scissor = Rect {
                 x: cmd.clip_rect.x.max(0.0).min(fb_width).round() as u16,
                 y: cmd.clip_rect.y.max(0.0).min(fb_height).round() as u16,
                 w: (cmd.clip_rect.z - cmd.clip_rect.x)
@@ -245,7 +269,14 @@ impl<R: Resources> Renderer<R> {
                     .min(fb_height)
                     .round() as u16,
             };
-            self.bundle.encode(encoder);
+            let data = pipe::BorrowedData {
+                vertex_buffer: &self.bundle.vertex_buffer,
+                matrix: matrix,
+                tex: tex,
+                out: &self.bundle.out,
+                scissor: &scissor,
+            };
+            encoder.draw(&self.bundle.slice, &self.bundle.pso, &data);
             self.bundle.slice.start = self.bundle.slice.end;
         }
         Ok(())
@@ -256,15 +287,15 @@ impl<R: Resources> Renderer<R> {
         encoder: &mut Encoder<R, C>,
         vtx_buffer: &[ImDrawVert],
     ) -> RendererResult<()> {
-        if self.bundle.data.vertex_buffer.len() < vtx_buffer.len() {
-            self.bundle.data.vertex_buffer = factory.create_buffer::<ImDrawVert>(
+        if self.bundle.vertex_buffer.len() < vtx_buffer.len() {
+            self.bundle.vertex_buffer = factory.create_buffer::<ImDrawVert>(
                 vtx_buffer.len(),
                 gfx::buffer::Role::Vertex,
                 gfx::memory::Usage::Dynamic,
                 Bind::empty(),
             )?;
         }
-        Ok(encoder.update_buffer(&self.bundle.data.vertex_buffer, vtx_buffer, 0)?)
+        Ok(encoder.update_buffer(&self.bundle.vertex_buffer, vtx_buffer, 0)?)
     }
     fn upload_index_buffer<F: Factory<R>, C: CommandBuffer<R>>(
         &mut self,
@@ -283,4 +314,11 @@ impl<R: Resources> Renderer<R> {
         }
         Ok(encoder.update_buffer(&self.index_buffer, idx_buffer, 0)?)
     }
+}
+
+struct Bundle<R: Resources, Data: PipelineData<R>> {
+    slice: Slice<R>,
+    pso: PipelineState<R, Data::Meta>,
+    vertex_buffer: Buffer<R, ImDrawVert>,
+    out: RenderTargetView<R, gfx::format::Rgba8>,
 }

--- a/imgui-gfx-renderer/src/lib.rs
+++ b/imgui-gfx-renderer/src/lib.rs
@@ -175,7 +175,7 @@ impl<R: Resources> Renderer<R> {
             factory.create_sampler(SamplerInfo::new(FilterMethod::Trilinear, WrapMode::Clamp));
         let pair = (texture, sampler);
         let mut textures = Textures::new();
-        imgui.set_texture_id(textures.insert(pair.clone()));
+        imgui.set_font_texture_id(textures.insert(pair.clone()));
 
         let slice = Slice {
             start: 0,

--- a/imgui-glium-renderer/src/lib.rs
+++ b/imgui-glium-renderer/src/lib.rs
@@ -241,7 +241,7 @@ impl DeviceObjects {
             Texture2d::new(ctx, data)
         })?;
         let mut textures = Textures::new();
-        im_gui.set_texture_id(textures.insert(texture));
+        im_gui.set_font_texture_id(textures.insert(texture));
 
         Ok(DeviceObjects {
             vertex_buffer: vertex_buffer,

--- a/src/image.rs
+++ b/src/image.rs
@@ -29,6 +29,7 @@ impl From<*mut c_void> for ImTexture {
 /// See [`Ui::image`].
 ///
 /// Create your image using the builder pattern then [`Image::build`] it.
+#[must_use]
 pub struct Image<'ui> {
     /// we use Result to allow postponing any construction errors to the build call
     texture_id: ImTexture,

--- a/src/image.rs
+++ b/src/image.rs
@@ -31,7 +31,6 @@ impl From<*mut c_void> for ImTexture {
 /// Create your image using the builder pattern then [`Image::build`] it.
 #[must_use]
 pub struct Image<'ui> {
-    /// we use Result to allow postponing any construction errors to the build call
     texture_id: ImTexture,
     size: ImVec2,
     uv0: ImVec2,
@@ -131,13 +130,12 @@ impl<T> Textures<T> {
         ImTexture(id)
     }
 
-    pub fn replace(&mut self, id: ImTexture, texture: T) {
-        assert!(self.textures.contains_key(&id.0));
-        self.textures.insert(id.0, texture);
+    pub fn replace(&mut self, id: ImTexture, texture: T) -> Option<T> {
+        self.textures.insert(id.0, texture)
     }
 
-    pub fn remove(&mut self, id: ImTexture) {
-        self.textures.remove(&id.0);
+    pub fn remove(&mut self, id: ImTexture) -> Option<T> {
+        self.textures.remove(&id.0)
     }
 
     pub fn get(&self, id: ImTexture) -> Option<&T> {

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,5 +1,6 @@
 use super::{ImVec2, ImVec4, Ui};
 use std::marker::PhantomData;
+use std::collections::HashMap;
 use std::os::raw::c_void;
 use sys;
 
@@ -86,5 +87,40 @@ impl<'ui> Image<'ui> {
                 self.border_col,
             );
         }
+    }
+}
+
+/// Generic texture mapping for use by renderers.
+pub struct Textures<T> {
+    textures: HashMap<usize, T>,
+    next: usize,
+}
+
+impl<T> Textures<T> {
+    pub fn new() -> Self {
+        Textures {
+            textures: HashMap::new(),
+            next: 0,
+        }
+    }
+
+    pub fn insert(&mut self, texture: T) -> ImTexture {
+        let id = self.next;
+        self.textures.insert(id, texture);
+        self.next += 1;
+        id
+    }
+
+    pub fn replace(&mut self, id: ImTexture, texture: T) {
+        assert!(self.textures.contains_key(&id));
+        self.textures.insert(id, texture);
+    }
+
+    pub fn remove(&mut self, id: ImTexture) {
+        self.textures.remove(&id);
+    }
+
+    pub fn get(&self, id: ImTexture) -> Option<&T> {
+        self.textures.get(&id)
     }
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,0 +1,90 @@
+use super::{ImVec2, ImVec4, Ui};
+use std::marker::PhantomData;
+use std::os::raw::c_void;
+use sys;
+
+pub type ImTexture = usize;
+
+/// Represent an image about to be drawn.
+/// See [`Ui::image`].
+///
+/// Create your image using the builder pattern then [`Image::build`] it.
+pub struct Image<'ui> {
+    /// we use Result to allow postponing any construction errors to the build call
+    texture_id: ImTexture,
+    size: ImVec2,
+    uv0: ImVec2,
+    uv1: ImVec2,
+    tint_col: ImVec4,
+    border_col: ImVec4,
+    _phantom: PhantomData<&'ui Ui<'ui>>,
+}
+
+impl<'ui> Image<'ui> {
+    pub fn new<S>(_: &Ui<'ui>, texture_id: usize, size: S) -> Self
+    where
+        S: Into<ImVec2>,
+    {
+        const DEFAULT_UV0: ImVec2 = ImVec2 { x: 0.0, y: 0.0 };
+        const DEFAULT_UV1: ImVec2 = ImVec2 { x: 1.0, y: 1.0 };
+        const DEFAULT_TINT_COL: ImVec4 = ImVec4 {
+            x: 1.0,
+            y: 1.0,
+            z: 1.0,
+            w: 1.0,
+        };
+        const DEFAULT_BORDER_COL: ImVec4 = ImVec4 {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+            w: 0.0,
+        };
+        Image {
+            texture_id: texture_id,
+            size: size.into(),
+            uv0: DEFAULT_UV0,
+            uv1: DEFAULT_UV1,
+            tint_col: DEFAULT_TINT_COL,
+            border_col: DEFAULT_BORDER_COL,
+            _phantom: PhantomData,
+        }
+    }
+    /// Set size (default based on texture)
+    pub fn size<T: Into<ImVec2>>(mut self, size: T) -> Self {
+        self.size = size.into();
+        self
+    }
+    /// Set uv0 (default `[0.0, 0.0]`)
+    pub fn uv0<T: Into<ImVec2>>(mut self, uv0: T) -> Self {
+        self.uv0 = uv0.into();
+        self
+    }
+    /// Set uv1 (default `[1.0, 1.0]`)
+    pub fn uv1<T: Into<ImVec2>>(mut self, uv1: T) -> Self {
+        self.uv1 = uv1.into();
+        self
+    }
+    /// Set tint color (default: no tint color)
+    pub fn tint_col<T: Into<ImVec4>>(mut self, tint_col: T) -> Self {
+        self.tint_col = tint_col.into();
+        self
+    }
+    /// Set border color (default: no border)
+    pub fn border_col<T: Into<ImVec4>>(mut self, border_col: T) -> Self {
+        self.border_col = border_col.into();
+        self
+    }
+    /// Draw image where the cursor currently is
+    pub fn build(self) {
+        unsafe {
+            sys::igImage(
+                self.texture_id as *mut c_void,
+                self.size,
+                self.uv0,
+                self.uv1,
+                self.tint_col,
+                self.border_col,
+            );
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub use drag::{
     DragInt4, DragIntRange2,
 };
 pub use fonts::{FontGlyphRange, ImFont, ImFontAtlas, ImFontConfig};
+pub use image::{ImTexture, Image};
 pub use input::{
     InputFloat, InputFloat2, InputFloat3, InputFloat4, InputInt, InputInt2, InputInt3, InputInt4,
     InputText, InputTextMultiline,
@@ -45,6 +46,7 @@ mod child_frame;
 mod color_editors;
 mod drag;
 mod fonts;
+mod image;
 mod input;
 mod menus;
 mod plothistogram;
@@ -1298,6 +1300,16 @@ impl<'ui> Ui<'ui> {
         values: &'p [f32],
     ) -> PlotHistogram<'ui, 'p> {
         PlotHistogram::new(self, label, values)
+    }
+}
+
+// Image
+impl<'ui> Ui<'ui> {
+    pub fn image<S>(&self, texture: ImTexture, size: S) -> Image
+    where
+        S: Into<ImVec2>,
+    {
+        Image::new(self, texture, size)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub use drag::{
     DragInt4, DragIntRange2,
 };
 pub use fonts::{FontGlyphRange, ImFont, ImFontAtlas, ImFontConfig};
-pub use image::{ImTexture, Image};
+pub use image::{ImTexture, Image, Textures};
 pub use input::{
     InputFloat, InputFloat2, InputFloat3, InputFloat4, InputInt, InputInt2, InputInt3, InputInt4,
     InputText, InputTextMultiline,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,8 +172,8 @@ impl ImGui {
             })
         }
     }
-    pub fn set_texture_id(&mut self, value: usize) {
-        self.fonts().set_texture_id(value);
+    pub fn set_texture_id(&mut self, value: ImTexture) {
+        self.fonts().set_texture_id(value.id());
     }
     pub fn set_ini_filename(&mut self, value: Option<ImString>) {
         {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ impl ImGui {
             })
         }
     }
-    pub fn set_texture_id(&mut self, value: ImTexture) {
+    pub fn set_font_texture_id(&mut self, value: ImTexture) {
         self.fonts().set_texture_id(value.id());
     }
     pub fn set_ini_filename(&mut self, value: Option<ImString>) {


### PR DESCRIPTION
Alternative to #122 and #149. The `Image` struct is based originally on that from #149.

Closes #65. Closes #122. Closes #149.

* `ImTexture` is a typesafe wrapper around a `usize`.
* `Ui::image(&self, ImTexture, ImVec2) -> Image` allows placing an image in the UI.
* `Textures<T>` can be re-used by renderers to keep `ImTexture` -> texture mappings.
  * Renderers can expose `textures(&mut self) -> Textures<_>` for a common interface.

Pros:
* API surface is small (one `Ui` method, three support structs)
* No need for separate `imgui-*-textured-renderer` crates.
* `ImTexture` is typesafe (not confusable with non-texture `usize`s).
* No need to assign/deal with string IDs for textures (just pass around `ImTexture`s).
* Works with both renderers.
* No `unsafe` in the texture logic.
* The font is not a special case: it's typically `ImTexture(0)` due to the renderers registering it first, but is otherwise just another texture as far as the renderers are concerned.

Cons:
* Requires applications wanting to use custom textures to know about their renderer. I think this is inevitable because they need to know what format textures are expected to be in.
* ~~`gfx` renderer involves cloning Arcs~~ Fixed
  * Number of clones could be reduced by only cloning when texture ID changes
  * Investigation says a true fix exists, but I will have to actually write the code later
* Texture registration takes ownership of the texture
  * The texture can be retrieved again with `Textures::get` (a `get_mut` could be added if needed)
  * Not a problem for `gfx` where textures are just handles

Action shot:

![image](https://user-images.githubusercontent.com/222630/45284738-17ab5a80-b496-11e8-8350-f9a7de694805.png)

TODO:
* [x] Reduce cloning in gfx renderer
* [ ] Write an example (port from #149?)
* [ ] Rustfmt
