### PR TITLE
Bumped max acceptable glutin version to 0.19

### DIFF
--- a/imgui-glutin-support/Cargo.toml
+++ b/imgui-glutin-support/Cargo.toml
@@ -12,5 +12,5 @@ categories = ["gui"]
 travis-ci = { repository = "Gekkio/imgui-rs" }
 
 [dependencies]
-glutin = ">= 0.17, <= 0.18"
+glutin = ">= 0.17, <= 0.19"
 imgui = { version = "0.0.22-pre", path = "../" }


### PR DESCRIPTION
Transitively brings a lot of fixes from winit updates: https://github.com/tomaka/winit/blob/v0.18.0/CHANGELOG.md#version-0180-2018-11-07