### PR TITLE
Updates examples path in README (glium examples moved to their own folder)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -51,12 +51,12 @@ ui.window(im_str!("Hello world"))
 
 ## Compiling and running the demos
 
-Examples are under the imgui-examples directory.
+Some examples for glium backend are under the imgui-glium-examples directory.
 
     git clone https://github.com/Gekkio/imgui-rs
     cd imgui-rs
     git submodule update --init --recursive
-    cd imgui-examples
+    cd imgui-glium-examples
     cargo test
 
     cargo run --example hello_world


### PR DESCRIPTION
**EDIT: I've submitted better PR #199**

~~Since the last release the examples for `glium` were moved into their own folder `imgui-glium-examples`.~~

~~The instructions in README specifically use these 'glium' examples, so the path needs to be updated there too.~~
