### PR TITLE
Add support for image buttons

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Support for image buttons: `Ui::image_button`
+
 ### Removed
 
 - Various things that were deprecated in imgui-rs 0.0.21 and 0.0.22

--- a/src/image.rs
+++ b/src/image.rs
@@ -109,6 +109,103 @@ impl<'ui> Image<'ui> {
     }
 }
 
+
+/// Represent an image button about to be drawn.
+/// See [`Ui::image`].
+///
+/// Create your image button using the builder pattern then [`ImageButton::build`] it.
+#[must_use]
+pub struct ImageButton<'ui> {
+    texture_id: ImTexture,
+    size: ImVec2,
+    uv0: ImVec2,
+    uv1: ImVec2,
+    frame_padding: i32,
+    bg_col: ImVec4,
+    tint_col: ImVec4,
+    _phantom: PhantomData<&'ui Ui<'ui>>,
+}
+
+impl<'ui> ImageButton<'ui> {
+    pub fn new<S>(_: &Ui<'ui>, texture_id: ImTexture, size: S) -> Self
+    where
+        S: Into<ImVec2>,
+    {
+        const DEFAULT_UV0: ImVec2 = ImVec2 { x: 0.0, y: 0.0 };
+        const DEFAULT_UV1: ImVec2 = ImVec2 { x: 1.0, y: 1.0 };
+        const DEFAULT_FRAME_PADDING: i32 = -1;
+        const DEFAULT_BG_COL: ImVec4 = ImVec4 {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+            w: 0.0,
+        };
+        const DEFAULT_TINT_COL: ImVec4 = ImVec4 {
+            x: 1.0,
+            y: 1.0,
+            z: 1.0,
+            w: 1.0,
+        };
+        ImageButton {
+            texture_id,
+            size: size.into(),
+            uv0: DEFAULT_UV0,
+            uv1: DEFAULT_UV1,
+            frame_padding: DEFAULT_FRAME_PADDING,
+            bg_col: DEFAULT_BG_COL,
+            tint_col: DEFAULT_TINT_COL,
+            _phantom: PhantomData,
+        }
+    }
+    /// Set size (default based on texture)
+    pub fn size<T: Into<ImVec2>>(mut self, size: T) -> Self {
+        self.size = size.into();
+        self
+    }
+    /// Set uv0 (default `[0.0, 0.0]`)
+    pub fn uv0<T: Into<ImVec2>>(mut self, uv0: T) -> Self {
+        self.uv0 = uv0.into();
+        self
+    }
+    /// Set uv1 (default `[1.0, 1.0]`)
+    pub fn uv1<T: Into<ImVec2>>(mut self, uv1: T) -> Self {
+        self.uv1 = uv1.into();
+        self
+    }
+    /// Set frame padding (default: uses frame padding from style).
+    /// frame_padding < 0: uses frame padding from style (default)
+    /// frame_padding = 0: no framing
+    /// frame_padding > 0: set framing size
+    pub fn frame_padding(mut self, frame_padding: i32) -> Self {
+        self.frame_padding = frame_padding.into();
+        self
+    }
+    /// Set tint color (default: no tint color)
+    pub fn tint_col<T: Into<ImVec4>>(mut self, tint_col: T) -> Self {
+        self.tint_col = tint_col.into();
+        self
+    }
+    /// Set background color (default: no background color)
+    pub fn background_col<T: Into<ImVec4>>(mut self, bg_col: T) -> Self {
+        self.bg_col = bg_col.into();
+        self
+    }
+    /// Draw image button where the cursor currently is
+    pub fn build(self) -> bool {
+        unsafe {
+            sys::igImageButton(
+                self.texture_id.0 as *mut c_void,
+                self.size,
+                self.uv0,
+                self.uv1,
+                self.frame_padding,
+                self.bg_col,
+                self.tint_col,
+            )
+        }
+    }
+}
+
 /// Generic texture mapping for use by renderers.
 #[derive(Debug, Default)]
 pub struct Textures<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub use self::drag::{
     DragInt4, DragIntRange2,
 };
 pub use self::fonts::{FontGlyphRange, ImFont, ImFontAtlas, ImFontConfig};
-pub use self::image::{ImTexture, Image, Textures};
+pub use self::image::{ImTexture, Image, ImageButton, Textures};
 pub use self::input::{
     InputFloat, InputFloat2, InputFloat3, InputFloat4, InputInt, InputInt2, InputInt3, InputInt4,
     InputText, InputTextMultiline,
@@ -1355,6 +1355,16 @@ impl<'ui> Ui<'ui> {
         S: Into<ImVec2>,
     {
         Image::new(self, texture, size)
+    }
+}
+
+// ImageButton
+impl<'ui> Ui<'ui> {
+    pub fn image_button<S>(&self, texture: ImTexture, size: S) -> ImageButton
+    where
+        S: Into<ImVec2>,
+    {
+        ImageButton::new(self, texture, size)
     }
 }
 


### PR DESCRIPTION
Found that image button support was missing, which we needed. So implemented it here.

Implementation is almost identical to `Image` just with some parameters being different, and that build returns if the button has been clicked or not.