### PR TITLE
Added set keyboard focus function to Ui

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -528,6 +528,11 @@ impl<'ui> Ui<'ui> {
         let io = self.imgui.io();
         io.want_capture_keyboard
     }
+    pub fn set_keyboard_focus_here(&self, offset: i32) {
+        unsafe {
+            sys::igSetKeyboardFocusHere(offset);
+        }
+    }
     pub fn framerate(&self) -> f32 {
         let io = self.imgui.io();
         io.framerate


### PR DESCRIPTION
I couldn't find anywhere that `igSertKeyboardFocusHere` was being used in the codebase, and I got tired of needing to re-focus my input text box after every time I hit Enter. I tried to pick a section of code that makes sense (alongside keyboard capture) for putting the function, but I'm happy to move it around if you guys think there's a better spot.

The usage for keeping an input text in focus is something like this:
```rust
if ui
    .input_text(im_str!(""), &mut state.search_string)
    .enter_returns_true(true)
    .build()
{
    // this refocuses the previous item which just lost from pressing enter
    ui.set_keyboard_focus_here(-1);
    // ...the rest of your code here
}
```