### PR TITLE
Allow InputText/InputTextMultiline to automatically resize their ImStrings if the user desires.

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -6,7 +6,7 @@ use std::os::raw::c_char;
 use std::str;
 
 #[derive(Clone, Hash, Ord, Eq, PartialOrd, PartialEq)]
-pub struct ImString(Vec<u8>);
+pub struct ImString(pub(crate) Vec<u8>);
 
 impl ImString {
     pub fn new<T: Into<String>>(value: T) -> ImString {
@@ -61,7 +61,7 @@ impl ImString {
     /// Dear imgui accesses pointers directly, so the length doesn't get updated when the contents
     /// change. This is normally OK, because Deref to ImStr always calculates the slice length
     /// based on contents. However, we need to refresh the length in some ImString functions.
-    fn refresh_len(&mut self) {
+    pub(crate) fn refresh_len(&mut self) {
         let len = self.to_str().len();
         unsafe {
             self.0.set_len(len);


### PR DESCRIPTION
This PR adds a method `resize_buffer` to InputText and InputTextMultiline, which if called, sets the flag `ImGuiInputTextFlags::CallbackResize` and passes a callback that allows dear imgui to resize the `ImString` when it reaches capacity. 

Writing the callback required making some of `ImString`'s implementation details `pub(crate)` instead of private. If this seems ugly to you, I can think of a couple ways to avoid it: 
- Move the callback function from a freestanding function in `input.rs` to `ImString` itself. This avoids changing visibility, but still creates code nonlocality.
- Factor out the code that alters the capacity of the `ImString` into a public method, so that the callback can use it from its current location. The downside is that this method would appear to be a general-purpose resize operation, but have potentially confusing side-effects (refreshing the internal Vec's length and including the null terminator in it).