### PR TITLE
Fixed a bug where get_time() returned bogus values

### DIFF
--- a/imgui-sys/src/lib.rs
+++ b/imgui-sys/src/lib.rs
@@ -1033,7 +1033,7 @@ extern "C" {
     pub fn igSetItemAllowOverlap();
     pub fn igIsRectVisible(size: ImVec2) -> bool;
     pub fn igIsRectVisibleVec2(rect_min: ImVec2, rect_max: ImVec2) -> bool;
-    pub fn igGetTime() -> c_float;
+    pub fn igGetTime() -> c_double;
     pub fn igGetFrameCount() -> c_int;
     pub fn igGetOverlayDrawList() -> *mut ImDrawList;
     pub fn igGetDrawListSharedData() -> *mut ImDrawListSharedData;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -390,7 +390,7 @@ impl ImGui {
             sys::ImGuiIO_AddInputCharactersUTF8(self.io_mut(), buf.as_ptr() as *const _);
         }
     }
-    pub fn get_time(&self) -> f32 {
+    pub fn get_time(&self) -> f64 {
         unsafe { sys::igGetTime() }
     }
     pub fn get_frame_count(&self) -> i32 {


### PR DESCRIPTION
See https://github.com/cimgui/cimgui/blob/67f3b097a5090dd074be959fb9c794bd75096a1c/cimgui.h#L1154