### PR TITLE
Fixed a bug where key states could get out of sync

### DIFF
--- a/imgui-winit-support/src/lib.rs
+++ b/imgui-winit-support/src/lib.rs
@@ -83,7 +83,7 @@
 
 use imgui::{FrameSize, ImGui, ImGuiKey, ImGuiMouseCursor};
 use winit::{
-    ElementState, Event, KeyboardInput, ModifiersState, MouseButton, MouseCursor, MouseScrollDelta,
+    DeviceEvent, ElementState, Event, KeyboardInput, ModifiersState, MouseButton, MouseCursor, MouseScrollDelta,
     TouchPhase, VirtualKeyCode, Window, WindowEvent,
 };
 
@@ -173,9 +173,19 @@ pub fn handle_event(
     window_hidpi_factor: f64,
     app_hidpi_factor: f64,
 ) {
-    if let Event::WindowEvent { ref event, .. } = event {
-        handle_window_event(imgui, event, window_hidpi_factor, app_hidpi_factor)
+    match event {
+        Event::WindowEvent { ref event, .. } => handle_window_event(imgui, event, window_hidpi_factor, app_hidpi_factor),
+        Event::DeviceEvent { ref event, .. } => handle_device_event(imgui, event),
+        _ => (),
     }
+}
+
+/// Update imgui state from winit device event
+pub fn handle_device_event(imgui: &mut ImGui, event: &DeviceEvent) {
+    match event {
+        DeviceEvent::Key(keyboard_input) => handle_keyboard_input(imgui, *keyboard_input),
+        _ => (),
+    };
 }
 
 /// Update imgui state from winit window event
@@ -187,7 +197,6 @@ pub fn handle_window_event(
 ) {
     use self::WindowEvent::*;
     match event {
-        KeyboardInput { input, .. } => handle_keyboard_input(imgui, *input),
         ReceivedCharacter(ch) => imgui.add_input_character(*ch),
         CursorMoved {
             position,


### PR DESCRIPTION
This fixes a bug where the state propagated to `imgui.set_key()` would be inaccurate when a key gets pressed while the glutin window is focused, but released while a different window is focused.

I discovered this issue while implementing a (native) File Open dialog which gets activated by pressing `Ctrl+O`. The window feeding the winit-support events would receive the two WindowEvents for `Ctrl` and `O` being pressed, but not the events for the keys being released. As a result, the `O` key got stuck in the pressed state from imgui's perspective.
As a side note, `Ctrl` key wasn't getting stuck because its state was being updated by `handle_modifiers(imgui, event.modifiers);` when I pressed escape to close the File Open dialog.

The `DeviceEvents` don't have this problem and are received regardless of the focused window. This change switches keyboard handling from using the `WindowEvents` to the `DeviceEvents` instead.