### PR TITLE
Implement `get_*_draw_list` and `DrawList` drawing functions

### DIFF
--- a/imgui-examples/examples/draw_list.rs
+++ b/imgui-examples/examples/draw_list.rs
@@ -1,0 +1,37 @@
+use imgui::*;
+
+mod support;
+
+fn main() {
+    support::init(file!()).main_loop(|run, ui| {
+        let red = (1.0, 0.0, 0.0).into();
+        let green = (0.0, 1.0, 0.0).into();
+        let blue = (0.5, 0.5, 1.0).into();
+
+        Window::new(im_str!("Hello draw list"))
+            .opened(run)
+            .size([250.0, 250.0], Condition::Once)
+            .build(&ui, || {
+                ui.text("Hello world!");
+
+                let window_draw_list = ui.get_window_draw_list();
+
+                // in screen space
+                window_draw_list.add_circle((250.0, 250.0).into(), 50.0, red, 25, 1.0);
+                window_draw_list.add_text((160.0, 280.0).into(), red, "window screen space");
+
+                // in window space
+                let p1 = ui.get_cursor_screen_pos();
+                window_draw_list.add_line(p1, sys::ImVec2::new(p1.x + 50.0, p1.y + 50.0), red, 1.0);
+                window_draw_list.add_text(sys::ImVec2::new(p1.x + 50.0, p1.y + 50.0), red, "window local");
+            });
+
+        let bg_draw_list = ui.get_background_draw_list();
+        bg_draw_list.add_circle((250.0, 250.0).into(), 100.0, blue, 25, 1.0);
+        bg_draw_list.add_text((100.0, 160.0).into(), blue, "background");
+
+        let fg_draw_list = ui.get_foreground_draw_list();
+        fg_draw_list.add_circle((250.0, 250.0).into(), 75.0, green, 25, 1.0);
+        fg_draw_list.add_text((100.0, 200.0).into(), green, "foreground");
+    });
+}

--- a/imgui-sys/src/lib.rs
+++ b/imgui-sys/src/lib.rs
@@ -225,3 +225,17 @@ fn test_imvec4_simple_memory_layout() {
     assert_eq!(&ref_a.z as *const _, &ref_b[2] as *const _);
     assert_eq!(&ref_a.w as *const _, &ref_b[3] as *const _);
 }
+
+impl From<ImVec2_Simple> for ImVec2 {
+    #[inline]
+    fn from(v: ImVec2_Simple) -> ImVec2 {
+        ImVec2::new(v.x, v.y)
+    }
+}
+
+impl From<ImVec4_Simple> for ImVec4 {
+    #[inline]
+    fn from(v: ImVec4_Simple) -> ImVec4 {
+        ImVec4::new(v.x, v.y, v.z, v.w)
+    }
+}

--- a/src/render/draw_data.rs
+++ b/src/render/draw_data.rs
@@ -1,9 +1,57 @@
 use std::mem;
+use std::os::raw::c_char;
 use std::slice;
 
 use crate::internal::{closure_callback_marker, fn_callback_marker, RawCast, RawWrapper};
 use crate::render::renderer::TextureId;
 use crate::sys;
+use crate::Ui;
+
+/// Wrap `ImU32` (a type typically used by ImGui to store packed colors)
+/// This type is used to represent the color of drawing primitives in ImGui's
+/// custom drawing API.
+///
+/// The type implements `From<ImU32>`, `From<ImVec4>`, `From<[f32; 4]>`,
+/// `From<[f32; 3]>`, `From<(f32, f32, f32, f32)>` and `From<(f32, f32, f32)>`
+/// for convenience. If alpha is not provided, it is assumed to be 1.0 (255).
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub struct ImColor(sys::ImU32);
+
+impl From<ImColor> for sys::ImU32 {
+    fn from(color: ImColor) -> Self {
+        color.0
+    }
+}
+
+impl From<sys::ImU32> for ImColor {
+    fn from(color: sys::ImU32) -> Self {
+        ImColor(color)
+    }
+}
+
+impl From<[f32; 4]> for ImColor {
+    fn from(v: [f32; 4]) -> Self {
+        ImColor(unsafe { sys::igColorConvertFloat4ToU32(v.into()) })
+    }
+}
+
+impl From<(f32, f32, f32, f32)> for ImColor {
+    fn from(v: (f32, f32, f32, f32)) -> Self {
+        ImColor(unsafe { sys::igColorConvertFloat4ToU32(v.into()) })
+    }
+}
+
+impl From<[f32; 3]> for ImColor {
+    fn from(v: [f32; 3]) -> Self {
+        [v[0], v[1], v[2], 1.0].into()
+    }
+}
+
+impl From<(f32, f32, f32)> for ImColor {
+    fn from(v: (f32, f32, f32)) -> Self {
+        [v.0, v.1, v.2, 1.0].into()
+    }
+}
 
 /// All draw data required to render a frame.
 #[repr(C)]
@@ -151,6 +199,535 @@ impl DrawList {
             }
         }
     }
+}
+
+/// Wrap `ptr` with a temporary lifetime. It's likely that `ptr` will live longer than `'a`, but the caller must ensure the returned value is only used when valid.
+unsafe fn wrap_draw_list<'a>(ptr: *mut sys::ImDrawList) -> &'a mut DrawList {
+    &mut *(ptr as *mut DrawList)
+}
+
+/// Functions for getting a `DrawList`.
+impl<'ui> Ui<'ui> {
+    pub fn get_cursor_screen_pos(&self) -> sys::ImVec2 {
+        unsafe { sys::igGetCursorScreenPos_nonUDT2().into() }
+    }
+
+    pub fn get_window_draw_list<'a>(&self) -> &'a mut DrawList {
+        unsafe { wrap_draw_list(sys::igGetWindowDrawList()) }
+    }
+
+    pub fn get_background_draw_list<'a>(&self) -> &'a mut DrawList {
+        unsafe { wrap_draw_list(sys::igGetBackgroundDrawList()) }
+    }
+
+    pub fn get_foreground_draw_list<'a>(&self) -> &'a mut DrawList {
+        unsafe { wrap_draw_list(sys::igGetForegroundDrawList()) }
+    }
+}
+
+/// Functions for drawing into a `DrawList`.
+impl DrawList {
+    pub fn push_clip_rect(
+        &mut self,
+        clip_rect_min: sys::ImVec2,
+        clip_rect_max: sys::ImVec2,
+        intersect_with_current_clip_rect: bool,
+    ) {
+        unsafe {
+            sys::ImDrawList_PushClipRect(
+                self.raw_mut(),
+                clip_rect_min,
+                clip_rect_max,
+                intersect_with_current_clip_rect,
+            );
+        }
+    }
+
+    pub fn push_clip_rect_full_screen(&mut self) {
+        unsafe {
+            sys::ImDrawList_PushClipRectFullScreen(self.raw_mut());
+        }
+    }
+
+    pub fn pop_clip_rect(&mut self) {
+        unsafe {
+            sys::ImDrawList_PopClipRect(self.raw_mut());
+        }
+    }
+
+    pub fn push_texture_id(&mut self, texture_id: TextureId) {
+        unsafe {
+            sys::ImDrawList_PushTextureID(self.raw_mut(), texture_id.id() as sys::ImTextureID);
+        }
+    }
+
+    pub fn pop_texture_id(&mut self) {
+        unsafe {
+            sys::ImDrawList_PopTextureID(self.raw_mut());
+        }
+    }
+
+    pub fn get_clip_rect_min(&mut self) -> sys::ImVec2 {
+        unsafe { sys::ImDrawList_GetClipRectMin_nonUDT2(self.raw_mut()).into() }
+    }
+
+    pub fn get_clip_rect_max(&mut self) -> sys::ImVec2 {
+        unsafe { sys::ImDrawList_GetClipRectMax_nonUDT2(self.raw_mut()).into() }
+    }
+
+    pub fn add_line(&mut self, a: sys::ImVec2, b: sys::ImVec2, col: ImColor, thickness: f32) {
+        unsafe {
+            sys::ImDrawList_AddLine(self.raw_mut(), a, b, col.into(), thickness);
+        }
+    }
+
+    pub fn add_rect(
+        &mut self,
+        a: sys::ImVec2,
+        b: sys::ImVec2,
+        col: ImColor,
+        rounding: f32,
+        rounding_corners_flags: sys::ImDrawCornerFlags_,
+        thickness: f32,
+    ) {
+        unsafe {
+            sys::ImDrawList_AddRect(
+                self.raw_mut(),
+                a,
+                b,
+                col.into(),
+                rounding,
+                rounding_corners_flags as i32,
+                thickness,
+            );
+        }
+    }
+
+    pub fn add_rect_filled(
+        &mut self,
+        a: sys::ImVec2,
+        b: sys::ImVec2,
+        col: ImColor,
+        rounding: f32,
+        rounding_corners_flags: sys::ImDrawCornerFlags_,
+    ) {
+        unsafe {
+            sys::ImDrawList_AddRectFilled(
+                self.raw_mut(),
+                a,
+                b,
+                col.into(),
+                rounding,
+                rounding_corners_flags as i32,
+            );
+        }
+    }
+
+    pub fn add_rect_filled_multi_color(
+        &mut self,
+        a: sys::ImVec2,
+        b: sys::ImVec2,
+        col_upr_left: ImColor,
+        col_upr_right: ImColor,
+        col_bot_right: ImColor,
+        col_bot_left: ImColor,
+    ) {
+        unsafe {
+            sys::ImDrawList_AddRectFilledMultiColor(
+                self.raw_mut(),
+                a,
+                b,
+                col_upr_left.into(),
+                col_upr_right.into(),
+                col_bot_right.into(),
+                col_bot_left.into(),
+            );
+        }
+    }
+
+    pub fn add_quad(
+        &mut self,
+        a: sys::ImVec2,
+        b: sys::ImVec2,
+        c: sys::ImVec2,
+        d: sys::ImVec2,
+        col: ImColor,
+        thickness: f32,
+    ) {
+        unsafe {
+            sys::ImDrawList_AddQuad(self.raw_mut(), a, b, c, d, col.into(), thickness);
+        }
+    }
+
+    pub fn add_quad_filled(
+        &mut self,
+        a: sys::ImVec2,
+        b: sys::ImVec2,
+        c: sys::ImVec2,
+        d: sys::ImVec2,
+        col: ImColor,
+    ) {
+        unsafe {
+            sys::ImDrawList_AddQuadFilled(self.raw_mut(), a, b, c, d, col.into());
+        }
+    }
+
+    pub fn add_triangle(
+        &mut self,
+        a: sys::ImVec2,
+        b: sys::ImVec2,
+        c: sys::ImVec2,
+        col: ImColor,
+        thickness: f32,
+    ) {
+        unsafe {
+            sys::ImDrawList_AddTriangle(self.raw_mut(), a, b, c, col.into(), thickness);
+        }
+    }
+
+    pub fn add_triangle_filled(
+        &mut self,
+        a: sys::ImVec2,
+        b: sys::ImVec2,
+        c: sys::ImVec2,
+        col: ImColor,
+    ) {
+        unsafe {
+            sys::ImDrawList_AddTriangleFilled(self.raw_mut(), a, b, c, col.into());
+        }
+    }
+
+    pub fn add_circle(
+        &mut self,
+        centre: sys::ImVec2,
+        radius: f32,
+        col: ImColor,
+        num_segments: i32,
+        thickness: f32,
+    ) {
+        unsafe {
+            sys::ImDrawList_AddCircle(
+                self.raw_mut(),
+                centre,
+                radius,
+                col.into(),
+                num_segments,
+                thickness,
+            );
+        }
+    }
+
+    pub fn add_circle_filled(
+        &mut self,
+        centre: sys::ImVec2,
+        radius: f32,
+        col: ImColor,
+        num_segments: i32,
+    ) {
+        unsafe {
+            sys::ImDrawList_AddCircleFilled(
+                self.raw_mut(),
+                centre,
+                radius,
+                col.into(),
+                num_segments,
+            );
+        }
+    }
+
+    pub fn add_text<T: AsRef<str>>(&mut self, pos: sys::ImVec2, col: ImColor, text: T) {
+        let s = text.as_ref();
+        unsafe {
+            let start = s.as_ptr();
+            let end = start.add(s.len());
+            sys::ImDrawList_AddText(
+                self.raw_mut(),
+                pos,
+                col.into(),
+                start as *const c_char,
+                end as *const c_char,
+            );
+        }
+    }
+
+    pub fn add_text_font_ptr<T: AsRef<str>>(
+        &mut self,
+        font: *mut sys::ImFont,
+        font_size: f32,
+        pos: sys::ImVec2,
+        col: ImColor,
+        text: T,
+        wrap_width: f32,
+        cpu_fine_clip_rect: &[f32; 4],
+    ) {
+        let s = text.as_ref();
+        unsafe {
+            let start = s.as_ptr();
+            let end = start.add(s.len());
+            sys::ImDrawList_AddTextFontPtr(
+                self.raw_mut(),
+                font,
+                font_size,
+                pos,
+                col.into(),
+                start as *const c_char,
+                end as *const c_char,
+                wrap_width,
+                cpu_fine_clip_rect.as_ptr() as *const sys::ImVec4,
+            );
+        }
+    }
+
+    pub fn add_image(
+        &mut self,
+        user_texture_id: TextureId,
+        a: sys::ImVec2,
+        b: sys::ImVec2,
+        uv_a: sys::ImVec2,
+        uv_b: sys::ImVec2,
+        col: ImColor,
+    ) {
+        unsafe {
+            sys::ImDrawList_AddImage(
+                self.raw_mut(),
+                user_texture_id.id() as sys::ImTextureID,
+                a,
+                b,
+                uv_a,
+                uv_b,
+                col.into(),
+            );
+        }
+    }
+
+    pub fn add_image_quad(
+        &mut self,
+        user_texture_id: TextureId,
+        a: sys::ImVec2,
+        b: sys::ImVec2,
+        c: sys::ImVec2,
+        d: sys::ImVec2,
+        uv_a: sys::ImVec2,
+        uv_b: sys::ImVec2,
+        uv_c: sys::ImVec2,
+        uv_d: sys::ImVec2,
+        col: ImColor,
+    ) {
+        unsafe {
+            sys::ImDrawList_AddImageQuad(
+                self.raw_mut(),
+                user_texture_id.id() as sys::ImTextureID,
+                a,
+                b,
+                c,
+                d,
+                uv_a,
+                uv_b,
+                uv_c,
+                uv_d,
+                col.into(),
+            );
+        }
+    }
+
+    pub fn add_image_rounded(
+        &mut self,
+        user_texture_id: TextureId,
+        a: sys::ImVec2,
+        b: sys::ImVec2,
+        uv_a: sys::ImVec2,
+        uv_b: sys::ImVec2,
+        col: ImColor,
+        rounding: f32,
+        rounding_corners: i32,
+    ) {
+        unsafe {
+            sys::ImDrawList_AddImageRounded(
+                self.raw_mut(),
+                user_texture_id.id() as sys::ImTextureID,
+                a,
+                b,
+                uv_a,
+                uv_b,
+                col.into(),
+                rounding,
+                rounding_corners,
+            );
+        }
+    }
+
+    pub fn add_polyline(
+        &mut self,
+        points: &[sys::ImVec2],
+        col: ImColor,
+        closed: bool,
+        thickness: f32,
+    ) {
+        unsafe {
+            sys::ImDrawList_AddPolyline(
+                self.raw_mut(),
+                points.as_ptr() as *const sys::ImVec2,
+                points.len() as i32,
+                col.into(),
+                closed,
+                thickness,
+            );
+        }
+    }
+
+    pub fn add_convex_poly_filled(&mut self, points: &[sys::ImVec2], col: ImColor) {
+        unsafe {
+            sys::ImDrawList_AddConvexPolyFilled(
+                self.raw_mut(),
+                points.as_ptr() as *const sys::ImVec2,
+                points.len() as i32,
+                col.into(),
+            );
+        }
+    }
+
+    pub fn add_bezier_curve(
+        &mut self,
+        pos0: sys::ImVec2,
+        cp0: sys::ImVec2,
+        cp1: sys::ImVec2,
+        pos1: sys::ImVec2,
+        col: ImColor,
+        thickness: f32,
+        num_segments: i32,
+    ) {
+        unsafe {
+            sys::ImDrawList_AddBezierCurve(
+                self.raw_mut(),
+                pos0,
+                cp0,
+                cp1,
+                pos1,
+                col.into(),
+                thickness,
+                num_segments,
+            );
+        }
+    }
+
+    pub fn path_clear(&mut self) {
+        unsafe {
+            sys::ImDrawList_PathClear(self.raw_mut());
+        }
+    }
+
+    pub fn path_line_to(&mut self, pos: sys::ImVec2) {
+        unsafe {
+            sys::ImDrawList_PathLineTo(self.raw_mut(), pos);
+        }
+    }
+
+    pub fn path_line_to_merge_duplicate(&mut self, pos: sys::ImVec2) {
+        unsafe {
+            sys::ImDrawList_PathLineToMergeDuplicate(self.raw_mut(), pos);
+        }
+    }
+
+    pub fn path_fill_convex(&mut self, col: ImColor) {
+        unsafe {
+            sys::ImDrawList_PathFillConvex(self.raw_mut(), col.into());
+        }
+    }
+
+    pub fn path_stroke(&mut self, col: ImColor, closed: bool, thickness: f32) {
+        unsafe {
+            sys::ImDrawList_PathStroke(self.raw_mut(), col.into(), closed, thickness);
+        }
+    }
+
+    pub fn path_arc_to(
+        &mut self,
+        centre: sys::ImVec2,
+        radius: f32,
+        a_min: f32,
+        a_max: f32,
+        num_segments: i32,
+    ) {
+        unsafe {
+            sys::ImDrawList_PathArcTo(self.raw_mut(), centre, radius, a_min, a_max, num_segments);
+        }
+    }
+
+    pub fn path_arc_to_fast(
+        &mut self,
+        centre: sys::ImVec2,
+        radius: f32,
+        a_min_of_12: i32,
+        a_max_of_12: i32,
+    ) {
+        unsafe {
+            sys::ImDrawList_PathArcToFast(self.raw_mut(), centre, radius, a_min_of_12, a_max_of_12);
+        }
+    }
+
+    pub fn path_bezier_curve_to(
+        &mut self,
+        p1: sys::ImVec2,
+        p2: sys::ImVec2,
+        p3: sys::ImVec2,
+        num_segments: i32,
+    ) {
+        unsafe {
+            sys::ImDrawList_PathBezierCurveTo(self.raw_mut(), p1, p2, p3, num_segments);
+        }
+    }
+
+    pub fn path_rect(
+        &mut self,
+        rect_min: sys::ImVec2,
+        rect_max: sys::ImVec2,
+        rounding: f32,
+        rounding_corners_flags: sys::ImDrawCornerFlags_,
+    ) {
+        unsafe {
+            sys::ImDrawList_PathRect(
+                self.raw_mut(),
+                rect_min,
+                rect_max,
+                rounding,
+                rounding_corners_flags as i32,
+            );
+        }
+    }
+
+    pub fn channels_split(&mut self, channels_count: i32) {
+        unsafe {
+            sys::ImDrawList_ChannelsSplit(self.raw_mut(), channels_count);
+        }
+    }
+
+    pub fn channels_merge(&mut self) {
+        unsafe {
+            sys::ImDrawList_ChannelsMerge(self.raw_mut());
+        }
+    }
+
+    pub fn channels_set_current(&mut self, channel_index: i32) {
+        unsafe {
+            sys::ImDrawList_ChannelsSetCurrent(self.raw_mut(), channel_index);
+        }
+    }
+
+    // The remaining functions are advanced or internal helpers
+    // CIMGUI_API void ImDrawList_AddCallback(ImDrawList* self,ImDrawCallback callback,void* callback_data);
+    // CIMGUI_API void ImDrawList_AddDrawCmd(ImDrawList* self);
+    // CIMGUI_API ImDrawList* ImDrawList_CloneOutput(ImDrawList* self);
+    // CIMGUI_API void ImDrawList_Clear(ImDrawList* self);
+    // CIMGUI_API void ImDrawList_ClearFreeMemory(ImDrawList* self);
+    // CIMGUI_API void ImDrawList_PrimReserve(ImDrawList* self,int idx_count,int vtx_count);
+    // CIMGUI_API void ImDrawList_PrimRect(ImDrawList* self,const ImVec2 a,const ImVec2 b,ImU32 col);
+    // CIMGUI_API void ImDrawList_PrimRectUV(ImDrawList* self,const ImVec2 a,const ImVec2 b,const ImVec2 uv_a,const ImVec2 uv_b,ImU32 col);
+    // CIMGUI_API void ImDrawList_PrimQuadUV(ImDrawList* self,const ImVec2 a,const ImVec2 b,const ImVec2 c,const ImVec2 d,const ImVec2 uv_a,const ImVec2 uv_b,const ImVec2 uv_c,const ImVec2 uv_d,ImU32 col);
+    // CIMGUI_API void ImDrawList_PrimWriteVtx(ImDrawList* self,const ImVec2 pos,const ImVec2 uv,ImU32 col);
+    // CIMGUI_API void ImDrawList_PrimWriteIdx(ImDrawList* self,ImDrawIdx idx);
+    // CIMGUI_API void ImDrawList_PrimVtx(ImDrawList* self,const ImVec2 pos,const ImVec2 uv,ImU32 col);
+    // CIMGUI_API void ImDrawList_UpdateClipRect(ImDrawList* self);
+    // CIMGUI_API void ImDrawList_UpdateTextureID(ImDrawList* self);
 }
 
 pub struct DrawCmdIterator<'a> {


### PR DESCRIPTION
Closes #220 (when 0.1 lands).

`ImDrawList_Get*DrawList` are very powerful functions and this PR exposes the capability in Rust.

- Uses `0.1`'s `AsRef<str>`-based way of passing in text.
- Uses `ImColor` from: https://github.com/Gekkio/imgui-rs/blob/1f5bb7c449e9f6f13dfd84640c426e7cdd91be49/src/window_draw_list.rs#L17-L53
- Does not implement the "advanced" (callbacks) or internal helper APIs
- Uses `ImVec2/4` and adds a conversion from `ImVec2/4_Simple` to `ImVec2/4`