### PR TITLE
Add name to FontConfig

### DIFF
--- a/src/fonts/atlas.rs
+++ b/src/fonts/atlas.rs
@@ -280,6 +280,7 @@ pub struct FontConfig {
     pub glyph_max_advance_x: f32,
     pub rasterizer_flags: u32,
     pub rasterizer_multiply: f32,
+    pub name: Option<String>,
 }
 
 impl Default for FontConfig {
@@ -296,6 +297,7 @@ impl Default for FontConfig {
             glyph_max_advance_x: f32::MAX,
             rasterizer_flags: 0,
             rasterizer_multiply: 1.0,
+            name: None,
         }
     }
 }
@@ -313,6 +315,17 @@ impl FontConfig {
         raw.GlyphMaxAdvanceX = self.glyph_max_advance_x;
         raw.RasterizerFlags = self.rasterizer_flags;
         raw.RasterizerMultiply = self.rasterizer_multiply;
+        if let Some(name) = self.name.as_ref() {
+            let bytes = name.as_bytes();
+            let mut len = bytes.len().max(raw.Name.len() - 1);
+            while !name.is_char_boundary(len) {
+                len -= 1;
+            }
+            unsafe {
+                bytes.as_ptr().copy_to(raw.Name.as_mut_ptr() as _, len);
+                raw.Name[len] = 0;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Allows for fonts to be named when loaded from memory. 

![image](https://user-images.githubusercontent.com/221559/61998470-a9a45d80-b07e-11e9-8dc7-6ba8dfbf1339.png)


