### PR TITLE
Disable return-type-c-linkage warning

### DIFF
--- a/imgui-sys/build.rs
+++ b/imgui-sys/build.rs
@@ -30,6 +30,8 @@ fn main() -> io::Result<()> {
         .define("CIMGUI_NO_EXPORT", None)
         .define("IMGUI_DISABLE_WIN32_FUNCTIONS", None)
         .define("IMGUI_DISABLE_OSX_FUNCTIONS", None);
+
+    build.flag("-Wno-return-type-c-linkage");
     for path in &CPP_FILES {
         assert_file_exists(path)?;
         build.file(path);

--- a/imgui-sys/build.rs
+++ b/imgui-sys/build.rs
@@ -31,7 +31,7 @@ fn main() -> io::Result<()> {
         .define("IMGUI_DISABLE_WIN32_FUNCTIONS", None)
         .define("IMGUI_DISABLE_OSX_FUNCTIONS", None);
 
-    build.flag("-Wno-return-type-c-linkage");
+    build.flag_if_supported("-Wno-return-type-c-linkage");
     for path in &CPP_FILES {
         assert_file_exists(path)?;
         build.file(path);


### PR DESCRIPTION
When building, I see a bunch of warnings:

```
warning: In file included from third-party/cimgui/cimgui.cpp:5:
warning: third-party/cimgui/cimgui.h:974:19: warning: 'igGetWindowPos' has C-linkage specified, but returns user-defined type 'ImVec2' which is incompatible with C [-Wreturn-type-c-linkage]
warning: CIMGUI_API ImVec2 igGetWindowPos(void);
warning:                   ^
warning: third-party/cimgui/cimgui.h:975:19: warning: 'igGetWindowSize' has C-linkage specified, but returns user-defined type 'ImVec2' which is incompatible with C [-Wreturn-type-c-linkage]
warning: CIMGUI_API ImVec2 igGetWindowSize(void);
```

I don't think these warnings are useful in this case. The returned values in question (ImVec2, ImVec4, ImColor) shouldn't pose any practical trouble. This change will suppress the warning. (Although I understand if you don't want to take this PR since it isn't targetted at just those types.)