### PR TITLE
Fix backspace text entry

### DIFF
--- a/imgui-winit-support/src/lib.rs
+++ b/imgui-winit-support/src/lib.rs
@@ -313,7 +313,13 @@ impl WinitPlatform {
                     _ => (),
                 }
             }
-            WindowEvent::ReceivedCharacter(ch) => io.add_input_character(ch),
+            WindowEvent::ReceivedCharacter(ch) => {
+                // Exclude the backspace key ('\u{7f}'). Otherwise we will insert this char and then
+                // delete it.
+                if ch != '\u{7f}' {
+                    io.add_input_character(ch)
+                }
+            }
             WindowEvent::CursorMoved { position, .. } => {
                 let position = self.scale_pos_from_winit(window, position);
                 io.mouse_pos = [position.x as f32, position.y as f32];

--- a/imgui-winit-support/src/lib.rs
+++ b/imgui-winit-support/src/lib.rs
@@ -352,7 +352,7 @@ impl WinitPlatform {
                     MouseButton::Left => io.mouse_down[0] = pressed,
                     MouseButton::Right => io.mouse_down[1] = pressed,
                     MouseButton::Middle => io.mouse_down[2] = pressed,
-                    MouseButton::Other(idx @ 0...4) => io.mouse_down[idx as usize] = pressed,
+                    MouseButton::Other(idx @ 0..=4) => io.mouse_down[idx as usize] = pressed,
                     _ => (),
                 }
             }


### PR DESCRIPTION
I had trouble with backspace not functioning properly on winit/macos. The issue was that character \u{7f} was being inserted, and then the backspace would delete that spurious character. I also fixed a compile warning from deprecated '...' since it was in the same file.