### PR TITLE
Small fix for missing .end() statement on new ComboBox causing a panic

### DIFF
--- a/src/widget/combo_box.rs
+++ b/src/widget/combo_box.rs
@@ -213,6 +213,7 @@ impl<'a> ComboBox<'a> {
                     result = true;
                 }
             }
+            _cb.end(ui);
         }
         result
     }


### PR DESCRIPTION
This is just a 1-liner fix for adding an end statement inside the new `build_simple` function in `ComboBox`. This statement wasn't calling `end()`, causing a panic from the `drop` of the `ComboToken`.

I just wanted to push this up so I don't diverge from master too much.