### PR TITLE
Fix ImageButton bool return value for pressed

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix ImageButton bool return value
+
 ### Changed
 
 - Fix backspace handling on macOS

--- a/src/widget/image.rs
+++ b/src/widget/image.rs
@@ -129,7 +129,7 @@ impl ImageButton {
         self
     }
     /// Builds the image button
-    pub fn build(self, _: &Ui) {
+    pub fn build(self, _: &Ui) -> bool {
         unsafe {
             sys::igImageButton(
                 self.texture_id.id() as *mut c_void,
@@ -139,7 +139,7 @@ impl ImageButton {
                 self.frame_padding,
                 self.bg_col.into(),
                 self.tint_col.into(),
-            );
+            )
         }
     }
 }


### PR DESCRIPTION
This was a regression in 0.2.0, in that large change the `build` function lost its return value so one couldn't check if the image button had been pressed or not.

Would it be possible to have a `0.2.1` published on crates.io with this fix?