### PR TITLE
Remove resources dir from published crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ license = "MIT/Apache-2.0"
 categories = ["gui", "api-bindings"]
 readme = "README.markdown"
 
+exclude = [
+    "/resources"
+]
+
 [badges]
 travis-ci = { repository = "Gekkio/imgui-rs" }
 


### PR DESCRIPTION
The fonts and image in /resources are only used by examples, but they are still included in the published crate, along with their licenses, even though they aren't used in downstream crates, so this just removes them from the published crate.

Alternatively, I could change it to move the resources into the examples directory and fix up the paths in the examples instead.