### PR TITLE
Implement ChildWindow::movable

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Add `ChildWindow::movable`
+
 ### Changed
 
 - Upgrade to cimgui / imgui 1.73

--- a/src/window/child_window.rs
+++ b/src/window/child_window.rs
@@ -83,6 +83,14 @@ impl<'a> ChildWindow<'a> {
         self.border = border;
         self
     }
+    /// Enables/disables moving the window when child window is dragged.
+    ///
+    /// Enabled by default.
+    #[inline]
+    pub fn movable(mut self, value: bool) -> Self {
+        self.flags.set(WindowFlags::NO_MOVE, !value);
+        self
+    }
     /// Enables/disables scrollbars (scrolling is still possible with the mouse or
     /// programmatically).
     ///


### PR DESCRIPTION
This PR adds the API that allows to set the NO_MOVE flag for a child
window. This API was missing: the NO_MOVE flag could only be set for a
Window.
If the NO_MOVE flag is set to True, (by calling
`ChildWindow::movable(false)`), then the window will not move when a
child window is dragged on.