### PR TITLE
Fix toggling of MenuItem and Selectable with build_with_ref

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -10,6 +10,11 @@
 
 - Various things that were deprecated in imgui-rs 0.2.0
 
+### Fixed
+
+- Fix toggling behavior on using `MenuItem::build_with_ref` and
+  `Selectable::build_with_ref`.
+
 ## [0.2.1] - 2019-09-09
 
 ### Fixed

--- a/src/widget/menu.rs
+++ b/src/widget/menu.rs
@@ -143,7 +143,7 @@ impl<'a> MenuItem<'a> {
     /// Builds the menu item using a mutable reference to selected state.
     pub fn build_with_ref(self, ui: &Ui, selected: &mut bool) -> bool {
         if self.selected(*selected).build(ui) {
-            *selected = true;
+            *selected = !*selected;
             true
         } else {
             false

--- a/src/widget/selectable.rs
+++ b/src/widget/selectable.rs
@@ -123,7 +123,7 @@ impl<'a> Selectable<'a> {
     /// Builds the selectable using a mutable reference to selected state.
     pub fn build_with_ref(self, ui: &Ui, selected: &mut bool) -> bool {
         if self.selected(*selected).build(ui) {
-            *selected = true;
+            *selected = !*selected;
             true
         } else {
             false


### PR DESCRIPTION
`Selectable` or `MenuItem` should be toggled on click when called with `build_with_ref`.
    
This is the behavior that is done in ImGui when  `bool ImGui::MenuItem(const char* label, const char* shortcut, bool*p_selected, bool enabled)` is called.

## Before the fix: Cannot toggle
![bug](https://user-images.githubusercontent.com/14120117/70291245-eeef4d80-181d-11ea-9d1d-a1ee92770c65.gif)


## After the fix: Can toggle (expected behavior)

![fix](https://user-images.githubusercontent.com/14120117/70291274-00d0f080-181e-11ea-80d5-3578f8e66816.gif)

With this fix, the `test_window_impl` example works just as the upstream C++ ImGui demo works.