### PR TITLE
Add support for winit 0.22, fix some clippy warnings

### DIFF
--- a/imgui-winit-support/Cargo.toml
+++ b/imgui-winit-support/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["gui"]
 imgui = { version = "0.4.0-pre", path = "../" }
 winit-19 = { version = ">= 0.16, <= 0.19", package = "winit", optional = true }
 winit-20 = { version = ">= 0.20, <= 0.21", package = "winit", optional = true }
+winit-22 = { version = "0.22", package = "winit", optional = true }
 
 [features]
-default = ["winit-20"]
+default = ["winit-22"]

--- a/imgui-winit-support/src/lib.rs
+++ b/imgui-winit-support/src/lib.rs
@@ -77,6 +77,9 @@ use winit_19 as winit;
 #[cfg(feature = "winit-20")]
 use winit_20 as winit;
 
+#[cfg(feature = "winit-22")]
+use winit_22 as winit;
+
 use imgui::{self, BackendFlags, ConfigFlags, Context, ImString, Io, Key, Ui};
 use std::cmp::Ordering;
 use winit::dpi::{LogicalPosition, LogicalSize};
@@ -87,8 +90,8 @@ use winit::{
     TouchPhase, VirtualKeyCode, Window, WindowEvent,
 };
 
-#[cfg(feature = "winit-20")]
-use winit_20::{
+#[cfg(any(feature = "winit-20", feature ="winit-22"))]
+use winit::{
     error::ExternalError,
     event::{
         DeviceEvent, ElementState, Event, KeyboardInput, MouseButton, MouseScrollDelta, TouchPhase,
@@ -210,7 +213,7 @@ impl WinitPlatform {
     ///
     /// * framebuffer scale (= DPI factor) is set
     /// * display size is set
-    #[cfg(feature = "winit-20")]
+    #[cfg(any(feature = "winit-20", feature ="winit-22"))]
     pub fn attach_window(&mut self, io: &mut Io, window: &Window, hidpi_mode: HiDpiMode) {
         let (hidpi_mode, hidpi_factor) = hidpi_mode.apply(window.scale_factor());
         self.hidpi_mode = hidpi_mode;
@@ -243,7 +246,7 @@ impl WinitPlatform {
     ///
     /// This utility function is useful if you are using a DPI mode other than default, and want
     /// your application to use the same logical coordinates as imgui-rs.
-    #[cfg(feature = "winit-20")]
+    #[cfg(any(feature = "winit-20", feature ="winit-22"))]
     pub fn scale_size_from_winit(
         &self,
         window: &Window,
@@ -277,7 +280,7 @@ impl WinitPlatform {
     ///
     /// This utility function is useful if you are using a DPI mode other than default, and want
     /// your application to use the same logical coordinates as imgui-rs.
-    #[cfg(feature = "winit-20")]
+    #[cfg(any(feature = "winit-20", feature ="winit-22"))]
     pub fn scale_pos_from_winit(
         &self,
         window: &Window,
@@ -311,7 +314,7 @@ impl WinitPlatform {
     ///
     /// This utility function is useful if you are using a DPI mode other than default, and want
     /// your application to use the same logical coordinates as imgui-rs.
-    #[cfg(feature = "winit-20")]
+    #[cfg(any(feature = "winit-20", feature ="winit-22"))]
     pub fn scale_pos_for_winit(
         &self,
         window: &Window,
@@ -408,6 +411,48 @@ impl WinitPlatform {
             _ => (),
         }
     }
+    /// Handles a winit event.
+    ///
+    /// This function performs the following actions (depends on the event):
+    ///
+    /// * window size / dpi factor changes are applied
+    /// * keyboard state is updated
+    /// * mouse state is updated
+    #[cfg(any(feature = "winit-22"))]
+    pub fn handle_event<T>(&mut self, io: &mut Io, window: &Window, event: &Event<T>) {
+        match *event {
+            Event::WindowEvent {
+                window_id,
+                ref event,
+            } if window_id == window.id() => {
+                // We need to track modifiers separately because some system like macOS, will
+                // not reliably send modifier states during certain events like ScreenCapture.
+                // Gotta let the people show off their pretty imgui widgets!
+                if let WindowEvent::ModifiersChanged(modifiers) = event {
+                    io.key_shift = modifiers.shift();
+                    io.key_ctrl = modifiers.ctrl();
+                    io.key_alt = modifiers.alt();
+                    io.key_super = modifiers.logo();
+                }
+
+                self.handle_window_event(io, window, event);
+            }
+            // Track key release events outside our window. If we don't do this,
+            // we might never see the release event if some other window gets focus.
+            Event::DeviceEvent {
+                event:
+                DeviceEvent::Key(KeyboardInput {
+                                     state: ElementState::Released,
+                                     virtual_keycode: Some(key),
+                                     ..
+                                 }),
+                ..
+            } => {
+                io.keys_down[key as usize] = false;
+            }
+            _ => (),
+        }
+    }
     #[cfg(feature = "winit-19")]
     fn handle_window_event(&mut self, io: &mut Io, window: &Window, event: &WindowEvent) {
         match *event {
@@ -494,7 +539,7 @@ impl WinitPlatform {
             _ => (),
         }
     }
-    #[cfg(feature = "winit-20")]
+    #[cfg(any(feature = "winit-20", feature = "winit-22"))]
     fn handle_window_event(&mut self, io: &mut Io, window: &Window, event: &WindowEvent) {
         match *event {
             WindowEvent::Resized(physical_size) => {
@@ -618,7 +663,7 @@ impl WinitPlatform {
     /// This function performs the following actions:
     ///
     /// * mouse cursor is repositioned (if requested by imgui-rs)
-    #[cfg(feature = "winit-20")]
+    #[cfg(any(feature = "winit-20", feature ="winit-22"))]
     pub fn prepare_frame(&self, io: &mut Io, window: &Window) -> Result<(), ExternalError> {
         if io.want_set_mouse_pos {
             let logical_pos = self.scale_pos_for_winit(
@@ -668,7 +713,7 @@ impl WinitPlatform {
     /// This function performs the following actions:
     ///
     /// * mouse cursor is changed and/or hidden (if requested by imgui-rs)
-    #[cfg(feature = "winit-20")]
+    #[cfg(any(feature = "winit-20", feature ="winit-22"))]
     pub fn prepare_render(&self, ui: &Ui, window: &Window) {
         let io = ui.io();
         if !io

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -72,6 +72,7 @@ pub(crate) unsafe extern "C" fn set_clipboard_text(user_data: *mut c_void, text:
 }
 
 /// # Clipboard
+#[allow(clippy::fn_address_comparisons)] // This is allowed because although function addresses wont be unique, we just care if its OURS
 impl<'ui> Ui<'ui> {
     /// Returns the current clipboard contents as text, or None if the clipboard is empty or cannot
     /// be accessed

--- a/src/drag.rs
+++ b/src/drag.rs
@@ -1,6 +1,5 @@
 use std::marker::PhantomData;
 use std::ptr;
-use sys;
 
 use super::{ImStr, Ui};
 

--- a/src/plothistogram.rs
+++ b/src/plothistogram.rs
@@ -1,7 +1,6 @@
 use std::marker::PhantomData;
 use std::os::raw::c_float;
 use std::{f32, mem, ptr};
-use sys;
 
 use super::{ImStr, Ui};
 

--- a/src/plotlines.rs
+++ b/src/plotlines.rs
@@ -1,7 +1,6 @@
 use std::marker::PhantomData;
 use std::os::raw::c_float;
 use std::{f32, mem, ptr};
-use sys;
 
 use super::{ImStr, Ui};
 

--- a/src/window_draw_list.rs
+++ b/src/window_draw_list.rs
@@ -1,4 +1,3 @@
-use sys;
 use sys::{ImDrawList, ImU32};
 
 use super::Ui;


### PR DESCRIPTION
This simply adds support for `winit 0.22`,  adding the appropriate changes where necessary and sharing feature flags with `winit-20` where possible.

Also fixed a few clippy warnings, since they were annoying me in my project.
