### PR TITLE
Clamp textures to border (BorderClamp / GL_CLAMP_TO_BORDER)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.38.0
+          - 1.40.0
         os:
           - ubuntu-latest
           - macos-latest

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -5,6 +5,7 @@
 ### Changed
 
 - Redesigned tree / collapsing header API
+- Bump minimum Rust version to 1.40 (at least xml-rs crate requires it)
 
 ## [0.3.1] - 2020-03-16
 

--- a/README.markdown
+++ b/README.markdown
@@ -2,7 +2,7 @@
 
 **Still fairly experimental!**
 
-Minimum Rust version: 1.38
+Minimum Rust version: 1.40
 
 Wrapped Dear ImGui version: 1.75
 

--- a/imgui-glium-renderer/src/lib.rs
+++ b/imgui-glium-renderer/src/lib.rs
@@ -5,7 +5,7 @@ use glium::backend::{Context, Facade};
 use glium::index::{self, PrimitiveType};
 use glium::program::ProgramChooserCreationError;
 use glium::texture::{ClientFormat, MipmapsOption, RawImage2d, TextureCreationError};
-use glium::uniforms::{MagnifySamplerFilter, MinifySamplerFilter};
+use glium::uniforms::{MagnifySamplerFilter, MinifySamplerFilter, SamplerWrapFunction};
 use glium::{
     program, uniform, vertex, Blend, DrawError, DrawParameters, IndexBuffer, Program, Rect,
     Surface, Texture2d, VertexBuffer,
@@ -198,6 +198,7 @@ impl Renderer {
                                     tex: self.lookup_texture(texture_id)?.sampled()
                                         .minify_filter(MinifySamplerFilter::Linear)
                                         .magnify_filter(MagnifySamplerFilter::Linear)
+                                        .wrap_function(SamplerWrapFunction::BorderClamp)
                                 },
                                 &DrawParameters {
                                     blend: Blend::alpha_blending(),


### PR DESCRIPTION
I have a zoomable texture that I render with `ImageButton` (I also need to handle mouse click event on it).
When I zoom out, the texture is repeated, because GL_REPEAT is the default for textures.
But I need to see where the texture begins and ends!
This PR changes the texture wrap_function to `BorderClamp`.

Before:
![image](https://user-images.githubusercontent.com/535593/78509130-17676400-778c-11ea-9473-a8b48867c7f7.png)


After:
![image](https://user-images.githubusercontent.com/535593/78509124-0fa7bf80-778c-11ea-8654-3acf91224f4d.png)
