### PR TITLE
Expose include path and native defines via `DEP_` env variables

### DIFF
--- a/imgui-sys/Cargo.toml
+++ b/imgui-sys/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/Gekkio/imgui-rs"
 license = "MIT/Apache-2.0"
 categories = ["gui", "external-ffi-bindings"]
 build = "build.rs"
+links = "imgui"
 
 [build-dependencies]
 cc = "1.0"

--- a/imgui-sys/build.rs
+++ b/imgui-sys/build.rs
@@ -2,6 +2,7 @@
 
 use std::fs;
 use std::io;
+use std::path::Path;
 
 const CPP_FILES: [&str; 5] = [
     "third-party/cimgui.cpp",
@@ -9,6 +10,13 @@ const CPP_FILES: [&str; 5] = [
     "third-party/imgui/imgui_demo.cpp",
     "third-party/imgui/imgui_draw.cpp",
     "third-party/imgui/imgui_widgets.cpp",
+];
+
+const DEFINES: &[(&str, Option<&str>)] = &[
+    // Disabled due to linking issues
+    ("CIMGUI_NO_EXPORT", None),
+    ("IMGUI_DISABLE_WIN32_FUNCTIONS", None),
+    ("IMGUI_DISABLE_OSX_FUNCTIONS", None),
 ];
 
 fn assert_file_exists(path: &str) -> io::Result<()> {
@@ -25,15 +33,18 @@ fn assert_file_exists(path: &str) -> io::Result<()> {
 }
 
 fn main() -> io::Result<()> {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    println!("cargo:THIRD_PARTY={}", manifest_dir.join("third-party").display());
+    for (key, value) in DEFINES.iter() {
+        println!("cargo:DEFINE_{}={}", key, value.unwrap_or(""));
+    }
     #[cfg(not(feature = "wasm"))]
     {
         let mut build = cc::Build::new();
         build.cpp(true);
-        // Disabled due to linking issues
-        build
-            .define("CIMGUI_NO_EXPORT", None)
-            .define("IMGUI_DISABLE_WIN32_FUNCTIONS", None)
-            .define("IMGUI_DISABLE_OSX_FUNCTIONS", None);
+        for (key, value) in DEFINES.iter() {
+            build.define(key, *value);
+        }
 
         build.flag_if_supported("-Wno-return-type-c-linkage");
         for path in &CPP_FILES {

--- a/imgui-sys/build.rs
+++ b/imgui-sys/build.rs
@@ -34,7 +34,10 @@ fn assert_file_exists(path: &str) -> io::Result<()> {
 
 fn main() -> io::Result<()> {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-    println!("cargo:THIRD_PARTY={}", manifest_dir.join("third-party").display());
+    println!(
+        "cargo:THIRD_PARTY={}",
+        manifest_dir.join("third-party").display()
+    );
     for (key, value) in DEFINES.iter() {
         println!("cargo:DEFINE_{}={}", key, value.unwrap_or(""));
     }


### PR DESCRIPTION
This allows downstream projects to access the include path for `cimgui.h` and `imgui/imgui.h` for compiling native imgui dependencies. 

The `third_party` directory path will be available to `build.rs` scripts via the  `DEP_IMGUI_THIRD_PARTY` environment variable. The defines are available via `DEP_IMGUI_DEFINE_xxx`.