### PR TITLE
Add glutin support to `imgui-winit-support`

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -34,8 +34,9 @@ Window::new(im_str!("Hello world"))
 * imgui-glium-renderer: Renderer implementation that uses the `glium` crate
 * imgui-gfx-renderer: Renderer implementation that uses the `gfx` crate (*not
   the new gfx-hal crate*)
-* imgui-winit-support: Backend platform implementation that uses the `winit`
-  crate (0.22 by default, but 0.19-0.21 are supported via feature flags)
+* imgui-winit-support: Backend platform implementation that uses either:
+  - `winit-0.22` by default (but 0.19-0.21 are supported via feature flags)
+  - `glutin-0.24` via a feature flag
 * imgui-sys: Low-level unsafe API (automatically generated)
 
 ## Features

--- a/imgui-winit-support/Cargo.toml
+++ b/imgui-winit-support/Cargo.toml
@@ -14,6 +14,7 @@ imgui = { version = "0.4.0", path = "../" }
 winit-19 = { version = ">= 0.16, <= 0.19", package = "winit", optional = true }
 winit-20 = { version = ">= 0.20, <= 0.21", package = "winit", optional = true }
 winit-22 = { version = "0.22", package = "winit", optional = true }
+glutin-24 = { version = "0.24", package = "glutin", optional = true }
 
 [features]
 default = ["winit-22"]

--- a/imgui-winit-support/Cargo.toml
+++ b/imgui-winit-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imgui-winit-support"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2018"
 authors = ["Joonas Javanainen <joonas.javanainen@gmail.com>", "imgui-rs contributors"]
 description = "winit support code for the imgui crate"

--- a/imgui-winit-support/src/lib.rs
+++ b/imgui-winit-support/src/lib.rs
@@ -80,6 +80,9 @@ use winit_20 as winit;
 #[cfg(feature = "winit-22")]
 use winit_22 as winit;
 
+#[cfg(feature = "glutin-24")]
+use glutin_24 as winit;
+
 use imgui::{self, BackendFlags, ConfigFlags, Context, ImString, Io, Key, Ui};
 use std::cmp::Ordering;
 use winit::dpi::{LogicalPosition, LogicalSize};
@@ -90,7 +93,7 @@ use winit::{
     TouchPhase, VirtualKeyCode, Window, WindowEvent,
 };
 
-#[cfg(any(feature = "winit-20", feature = "winit-22"))]
+#[cfg(any(feature = "winit-20", feature = "winit-22", feature = "glutin-24"))]
 use winit::{
     error::ExternalError,
     event::{
@@ -139,7 +142,7 @@ impl CursorSettings {
             _ => window.hide_cursor(true),
         }
     }
-    #[cfg(any(feature = "winit-20", feature = "winit-22"))]
+    #[cfg(any(feature = "winit-20", feature = "winit-22", feature = "glutin-24"))]
     fn apply(&self, window: &Window) {
         match self.cursor {
             Some(mouse_cursor) if !self.draw_cursor => {
@@ -258,7 +261,7 @@ impl WinitPlatform {
     ///
     /// * framebuffer scale (= DPI factor) is set
     /// * display size is set
-    #[cfg(any(feature = "winit-20", feature = "winit-22"))]
+    #[cfg(any(feature = "winit-20", feature = "winit-22", feature = "glutin-24"))]
     pub fn attach_window(&mut self, io: &mut Io, window: &Window, hidpi_mode: HiDpiMode) {
         let (hidpi_mode, hidpi_factor) = hidpi_mode.apply(window.scale_factor());
         self.hidpi_mode = hidpi_mode;
@@ -291,7 +294,7 @@ impl WinitPlatform {
     ///
     /// This utility function is useful if you are using a DPI mode other than default, and want
     /// your application to use the same logical coordinates as imgui-rs.
-    #[cfg(any(feature = "winit-20", feature = "winit-22"))]
+    #[cfg(any(feature = "winit-20", feature = "winit-22", feature = "glutin-24"))]
     pub fn scale_size_from_winit(
         &self,
         window: &Window,
@@ -325,7 +328,7 @@ impl WinitPlatform {
     ///
     /// This utility function is useful if you are using a DPI mode other than default, and want
     /// your application to use the same logical coordinates as imgui-rs.
-    #[cfg(any(feature = "winit-20", feature = "winit-22"))]
+    #[cfg(any(feature = "winit-20", feature = "winit-22", feature = "glutin-24"))]
     pub fn scale_pos_from_winit(
         &self,
         window: &Window,
@@ -359,7 +362,7 @@ impl WinitPlatform {
     ///
     /// This utility function is useful if you are using a DPI mode other than default, and want
     /// your application to use the same logical coordinates as imgui-rs.
-    #[cfg(any(feature = "winit-20", feature = "winit-22"))]
+    #[cfg(any(feature = "winit-20", feature = "winit-22", feature = "glutin-24"))]
     pub fn scale_pos_for_winit(
         &self,
         window: &Window,
@@ -463,7 +466,7 @@ impl WinitPlatform {
     /// * window size / dpi factor changes are applied
     /// * keyboard state is updated
     /// * mouse state is updated
-    #[cfg(any(feature = "winit-22"))]
+    #[cfg(any(feature = "winit-22", feature = "glutin-24"))]
     pub fn handle_event<T>(&mut self, io: &mut Io, window: &Window, event: &Event<T>) {
         match *event {
             Event::WindowEvent {
@@ -584,7 +587,7 @@ impl WinitPlatform {
             _ => (),
         }
     }
-    #[cfg(any(feature = "winit-20", feature = "winit-22"))]
+    #[cfg(any(feature = "winit-20", feature = "winit-22", feature = "glutin-24"))]
     fn handle_window_event(&mut self, io: &mut Io, window: &Window, event: &WindowEvent) {
         match *event {
             WindowEvent::Resized(physical_size) => {
@@ -708,7 +711,7 @@ impl WinitPlatform {
     /// This function performs the following actions:
     ///
     /// * mouse cursor is repositioned (if requested by imgui-rs)
-    #[cfg(any(feature = "winit-20", feature = "winit-22"))]
+    #[cfg(any(feature = "winit-20", feature = "winit-22", feature = "glutin-24"))]
     pub fn prepare_frame(&self, io: &mut Io, window: &Window) -> Result<(), ExternalError> {
         if io.want_set_mouse_pos {
             let logical_pos = self.scale_pos_for_winit(


### PR DESCRIPTION
Surprisingly trivial, all I needed to do was add a cfg condition to wherever there was a winit-22 condition.

Working test [Gitlab - 8bitkitkat/imgui-winit-supoort-gluin-test](https://gitlab.com/8BitKitKat/imgui-winit-support-glutin-test)