### PR TITLE
Add comments to DrawCmd

### DIFF
--- a/src/render/draw_data.rs
+++ b/src/render/draw_data.rs
@@ -198,6 +198,7 @@ pub type DrawIdx = sys::ImDrawIdx;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct DrawCmdParams {
+    /// left, up, right, down
     pub clip_rect: [f32; 4],
     pub texture_id: TextureId,
     pub vtx_offset: usize,
@@ -207,6 +208,7 @@ pub struct DrawCmdParams {
 /// A draw command
 pub enum DrawCmd {
     Elements {
+        /// The number of indices used for this draw command
         count: usize,
         cmd_params: DrawCmdParams,
     },


### PR DESCRIPTION
This PR adds two line of comments that are useful to who want to implement custom renderer.

It lets users know:

* `clip_rect`: it's `[left, up, right, down]` not `[x, y, w, h]`
* `count`: it's the number of indices not the number of triangles
---
Thank you for sharing the awesome crate!