### PR TITLE
menu rewrite

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -24,7 +24,7 @@
 
 - Added `add_polyline` method to `DrawListMut`, which binds to Dear ImGui's `AddPolyline` and `AddConvexPolyFilled`
 
-- BREAKING: `MenuItem::new` now takes `&ui`, but has been deprecated. Instead, use `ui.menu_item`.
+- BREAKING: `MenuItem::new` now takes `&ui`, but has been deprecated. Instead, use `ui.menu_item`. Additionally, a `ui.menu_item_config` has been created to access the builder pattern on `MenuItem`.
 
 ## [0.8.0] - 2021-09-17
 

--- a/imgui-examples/examples/test_window_impl.rs
+++ b/imgui-examples/examples/test_window_impl.rs
@@ -342,22 +342,22 @@ fn show_test_window(ui: &Ui, state: &mut State, opened: &mut bool) {
                 menu.end();
             }
             if let Some(_t) = ui.begin_menu("Examples") {
-                ui.menu_item_selected_ref("Main menu bar", &mut state.show_app_main_menu_bar);
-                ui.menu_item_selected_ref("Console", &mut state.show_app_console);
-                ui.menu_item_selected_ref("Log", &mut state.show_app_log);
-                ui.menu_item_selected_ref("Simple layout", &mut state.show_app_layout);
-                ui.menu_item_selected_ref("Property editor", &mut state.show_app_property_editor);
-                ui.menu_item_selected_ref("Long text display", &mut state.show_app_long_text);
-                ui.menu_item_selected_ref("Auto-resizing window", &mut state.show_app_auto_resize);
-                ui.menu_item_selected_ref("Constrained-resizing window", &mut state.show_app_constrained_resize);
-                ui.menu_item_selected_ref("Simple overlay", &mut state.show_app_fixed_overlay);
-                ui.menu_item_selected_ref("Manipulating window title", &mut state.show_app_manipulating_window_title);
-                ui.menu_item_selected_ref("Custom Rendering", &mut state.show_app_custom_rendering);
+                ui.menu_item_config("Main menu bar").build_with_ref(&mut state.show_app_main_menu_bar);
+                ui.menu_item_config("Console").build_with_ref(&mut state.show_app_console);
+                ui.menu_item_config("Log").build_with_ref(&mut state.show_app_log);
+                ui.menu_item_config("Simple layout").build_with_ref(&mut state.show_app_layout);
+                ui.menu_item_config("Property editor").build_with_ref(&mut state.show_app_property_editor);
+                ui.menu_item_config("Long text display").build_with_ref(&mut state.show_app_long_text);
+                ui.menu_item_config("Auto-resizing window").build_with_ref(&mut state.show_app_auto_resize);
+                ui.menu_item_config("Constrained-resizing window").build_with_ref(&mut state.show_app_constrained_resize);
+                ui.menu_item_config("Simple overlay").build_with_ref(&mut state.show_app_fixed_overlay);
+                ui.menu_item_config("Manipulating window title").build_with_ref(&mut state.show_app_manipulating_window_title);
+                ui.menu_item_config("Custom Rendering").build_with_ref(&mut state.show_app_custom_rendering);
             }
             if let Some(_menu) = ui.begin_menu("Help") {
-                ui.menu_item_selected_ref("Metrics", &mut state.show_app_metrics);
-                ui.menu_item_selected_ref("Style Editor", &mut state.show_app_style_editor);
-                ui.menu_item_selected_ref("About ImGui", &mut state.show_app_about);
+                ui.menu_item_config("Metrics").build_with_ref(&mut state.show_app_metrics);
+                ui.menu_item_config("Style Editor").build_with_ref(&mut state.show_app_style_editor);
+                ui.menu_item_config("About ImGui").build_with_ref(&mut state.show_app_about);
             }
         }
         ui.spacing();
@@ -826,15 +826,15 @@ fn show_example_app_main_menu_bar(ui: &Ui, state: &mut State) {
             menu.end();
         }
         if let Some(menu) = ui.begin_menu("Edit") {
-            ui.menu_item_shortcut("Undo", "CTRL+Z");
+            ui.menu_item_config("Undo").shortcut("CTRL+Z").build();
             ui.menu_item_config("Redo")
                 .shortcut("CTRL+Y")
                 .enabled(false)
                 .build();
             ui.separator();
-            ui.menu_item_shortcut("Cut", "CTRL+X");
-            ui.menu_item_shortcut("Copy", "CTRL+C");
-            ui.menu_item_shortcut("Paste", "CTRL+V");
+            ui.menu_item_config("Cut").shortcut("CTRL+X").build();
+            ui.menu_item_config("Copy").shortcut("CTRL+C").build();
+            ui.menu_item_config("Paste").shortcut("CTRL+V").build();
             menu.end();
         }
         menu_bar.end();
@@ -842,9 +842,9 @@ fn show_example_app_main_menu_bar(ui: &Ui, state: &mut State) {
 }
 
 fn show_example_menu_file(ui: &Ui, state: &mut FileMenuState) {
-    ui.menu_item_enabled("(dummy_menu)", false);
+    ui.menu_item_config("(dummy_menu)").enabled(false).build();
     ui.menu_item("New");
-    ui.menu_item_shortcut("Open", "Ctrl+O");
+    ui.menu_item_config("Open").shortcut("Ctrl+O").build();
     if let Some(_menu) = ui.begin_menu("Open Recent") {
         ui.menu_item("fish_hat.c");
         ui.menu_item("fish_hat.inl");
@@ -859,11 +859,12 @@ fn show_example_menu_file(ui: &Ui, state: &mut FileMenuState) {
             }
         }
     }
-    ui.menu_item_shortcut("Save", "Ctrl+S");
+    ui.menu_item_config("Save").shortcut("Ctrl+S").build();
     ui.menu_item("Save As..");
     ui.separator();
     if let Some(_menu) = ui.begin_menu("Options") {
-        ui.menu_item_selected_ref("Enabled", &mut state.enabled);
+        ui.menu_item_config("Enabled")
+            .build_with_ref(&mut state.enabled);
 
         ui.child_window("child")
             .size([0.0, 60.0])
@@ -886,8 +887,8 @@ fn show_example_menu_file(ui: &Ui, state: &mut FileMenuState) {
         }
     }
     assert!(ui.begin_menu_with_enabled("Disabled", false).is_none());
-    ui.menu_item_selected("Checked", true);
-    ui.menu_item_shortcut("Quit", "Alt+F4");
+    ui.menu_item_config("Checked").selected(true).build();
+    ui.menu_item_config("Quit").shortcut("Alt+F4").build();
 }
 
 fn show_example_app_auto_resize(ui: &Ui, state: &mut AutoResizeState, opened: &mut bool) {

--- a/imgui/src/widget/menu.rs
+++ b/imgui/src/widget/menu.rs
@@ -110,43 +110,22 @@ impl Ui {
 
     /// Creates a menu item with the given label, returning `true` if it was pressed.
     ///
+    /// If you want to configure this `menu_item` by setting `selection`, or `enablement`,
+    /// use [`menu_item_config`].
+    ///
     /// Note: a `menu_item` is the actual button/selectable within a Menu.
+    ///
+    /// [`menu_item_config`]: Self::menu_item_config
+    #[doc(alias = "MenuItem")]
     pub fn menu_item(&self, label: impl AsRef<str>) -> bool {
         self.menu_item_config(label).build()
     }
 
-    /// Creates a menu item with the given label and enablement, returning `true` if it was pressed.
+    /// Creates a menu item builder, with further methods on it as needed. Use [`menu_item`]
+    /// for simple Menu Items with no features on them.
     ///
     /// Note: a `menu_item` is the actual button/selectable within a Menu.
-    pub fn menu_item_enabled(&self, label: impl AsRef<str>, enabled: bool) -> bool {
-        self.menu_item_config(label).enabled(enabled).build()
-    }
-
-    /// Creates a menu item with the given label and selection, returning `true` if it was pressed.
-    ///
-    /// Note: a `menu_item` is the actual button/selectable within a Menu.
-    pub fn menu_item_selected(&self, label: impl AsRef<str>, selected: bool) -> bool {
-        self.menu_item_config(label).selected(selected).build()
-    }
-
-    /// Creates a menu item with the given label and selection, returning `true` if it was pressed,
-    /// while mutating `selected` to the correct state.
-    ///
-    /// Note: a `menu_item` is the actual button/selectable within a Menu.
-    pub fn menu_item_selected_ref(&self, label: impl AsRef<str>, selected: &mut bool) -> bool {
-        self.menu_item_config(label).build_with_ref(selected)
-    }
-
-    /// Creates a menu item with the given label and shortcut, returning `true` if it was pressed.
-    ///
-    /// Note: a `menu_item` is the actual button/selectable within a Menu.
-    pub fn menu_item_shortcut(&self, label: impl AsRef<str>, shortcut: impl AsRef<str>) -> bool {
-        self.menu_item_config(label).shortcut(shortcut).build()
-    }
-
-    // Creates a menu item builder, with further methods on it as needed.
-    //
-    // Note: a `menu_item` is the actual button/selectable within a Menu.
+    #[doc(alias = "MenuItem")]
     pub fn menu_item_config<L: AsRef<str>>(&self, label: L) -> MenuItem<'_, L> {
         MenuItem {
             label,


### PR DESCRIPTION
Moved the Menu-Item constructors onto `ui`.

I'm pleased with how this API looks, so I'm going to write this out. If @dbr and @thomcc also agree with this kind of design, I'll add this to our docs and aim to keep this format for most of our overload-style code.

1. `ui.menu_item` creates a `menu_item` with just a label, and nothing else. This function returns a bool directly -- this means that users don't have to write `.build` at all. This allows for fast code to be written easily.
2. `ui.menu_item_x` are made for common overloads of a single value. So for `menu_item`, I bound all of them the various parameters, since they're common enough -- so we have a `ui.menu_item_shortcut`, `ui.menu_item_selected`, `ui.menu_item_enabled`, etc. These, like the main simple one, return *bool*, not the Builder struct, so users shouldn't have to type `.build` themselves.
3. `ui.menu_item_config` takes the same parameters as our basic `ui.menu_item`, but returns a Builder instead (ie, users need to type `.build()` at the end). For less common situations, we can use this builder to generate complex forms.

This should be generalizable to the vast majority of our builder structures, and in my code, made this as easy as it could be in a language without optional arguments. Optional arguments would be nice...

What do you think? imo, it would be nice if at least MOST of the library worked in a similar way
