### PR TITLE
fix: check memory boundaries before using slice::from_raw_parts

### DIFF
--- a/imgui/src/render/draw_data.rs
+++ b/imgui/src/render/draw_data.rs
@@ -60,8 +60,8 @@ impl DrawData {
             return &[];
         }
         slice::from_raw_parts(
-            self.cmd_lists as *const *const DrawList, 
-            self.cmd_lists_count as usize
+            self.cmd_lists as *const *const DrawList,
+            self.cmd_lists_count as usize,
         )
     }
     /// Converts all buffers from indexed to non-indexed, in case you cannot render indexed
@@ -149,16 +149,14 @@ impl RawWrapper for DrawList {
 impl DrawList {
     #[inline]
     pub(crate) unsafe fn cmd_buffer(&self) -> &[sys::ImDrawCmd] {
-        unsafe {
-            if self.0.CmdBuffer.Size <= 0 || self.0.CmdBuffer.Data.is_null() {
-                return &[];
-            }
-
-            slice::from_raw_parts(
-                self.0.CmdBuffer.Data as *const sys::ImDrawCmd,
-                self.0.CmdBuffer.Size as usize,
-            )
+        if self.0.CmdBuffer.Size <= 0 || self.0.CmdBuffer.Data.is_null() {
+            return &[];
         }
+
+        slice::from_raw_parts(
+            self.0.CmdBuffer.Data as *const sys::ImDrawCmd,
+            self.0.CmdBuffer.Size as usize,
+        )
     }
 
     #[inline]

--- a/imgui/src/render/draw_data.rs
+++ b/imgui/src/render/draw_data.rs
@@ -56,9 +56,12 @@ impl DrawData {
     }
     #[inline]
     pub(crate) unsafe fn cmd_lists(&self) -> &[*const DrawList] {
+        if self.cmd_lists_count <= 0 || self.cmd_lists.is_null() {
+            return &[];
+        }
         slice::from_raw_parts(
-            self.cmd_lists as *const *const DrawList,
-            self.cmd_lists_count as usize,
+            self.cmd_lists as *const *const DrawList, 
+            self.cmd_lists_count as usize
         )
     }
     /// Converts all buffers from indexed to non-indexed, in case you cannot render indexed
@@ -146,23 +149,39 @@ impl RawWrapper for DrawList {
 impl DrawList {
     #[inline]
     pub(crate) unsafe fn cmd_buffer(&self) -> &[sys::ImDrawCmd] {
-        slice::from_raw_parts(
-            self.0.CmdBuffer.Data as *const sys::ImDrawCmd,
-            self.0.CmdBuffer.Size as usize,
-        )
+        unsafe {
+            if self.0.CmdBuffer.Size <= 0 || self.0.CmdBuffer.Data.is_null() {
+                return &[];
+            }
+
+            slice::from_raw_parts(
+                self.0.CmdBuffer.Data as *const sys::ImDrawCmd,
+                self.0.CmdBuffer.Size as usize,
+            )
+        }
     }
+
     #[inline]
     pub fn idx_buffer(&self) -> &[DrawIdx] {
         unsafe {
+            if self.0.IdxBuffer.Size <= 0 || self.0.IdxBuffer.Data.is_null() {
+                return &[];
+            }
+
             slice::from_raw_parts(
                 self.0.IdxBuffer.Data as *const DrawIdx,
                 self.0.IdxBuffer.Size as usize,
             )
         }
     }
+
     #[inline]
     pub fn vtx_buffer(&self) -> &[DrawVert] {
         unsafe {
+            if self.0.VtxBuffer.Size <= 0 || self.0.VtxBuffer.Data.is_null() {
+                return &[];
+            }
+
             slice::from_raw_parts(
                 self.0.VtxBuffer.Data as *const DrawVert,
                 self.0.VtxBuffer.Size as usize,
@@ -181,7 +200,14 @@ impl DrawList {
             core::mem::size_of::<DrawVert>(),
         );
         assert!(core::mem::align_of::<VTy>() <= core::mem::align_of::<DrawVert>());
-        slice::from_raw_parts(self.0.VtxBuffer.Data.cast(), self.0.VtxBuffer.Size as usize)
+        if self.0.VtxBuffer.Size <= 0 || self.0.VtxBuffer.Data.is_null() {
+            return &[];
+        }
+
+        slice::from_raw_parts(
+            self.0.VtxBuffer.Data as *const VTy,
+            self.0.VtxBuffer.Size as usize,
+        )
     }
 
     #[inline]


### PR DESCRIPTION
In rustc 1.78  `ub_checks::assert_unsafe_precondition` was added to `slice::from_raw_parts`
```rs
        ub_checks::assert_unsafe_precondition!(
            check_language_ub,
            "slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`",
            (
                data: *mut () = data as *mut (),
                size: usize = size_of::<T>(),
                align: usize = align_of::<T>(),
                len: usize = len,
            ) =>
            ub_checks::is_aligned_and_not_null(data, align)
                && ub_checks::is_valid_allocation_size(size, len)
        );
```

This causes the rendering code in `draw_data.rs` to panic during runtime. This fix adds checks before creating the slice and if they fail returns an empty slice. 

Validated on WSL2/Ubuntu 22.04

Addresses #777